### PR TITLE
Docker compose deploy

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -1,26 +1,23 @@
-name: ci
+name: Docker Build and Push
 
 on:
   push:
+    branches: ['main']
 
 jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to Docker Hub
+      - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Build and push
+      - name: Build and push
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
-
-name: Node.js CI
+name: Node.js Code Quality
 
 on:
   push:
@@ -26,8 +23,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
-<<<<<<< HEAD
       - run: npm run format-check
-=======
->>>>>>> 1fde21a (Docker compose deploy script to deploy with watchtower)
-      - run: npm run build

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,5 +26,8 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
+<<<<<<< HEAD
       - run: npm run format-check
+=======
+>>>>>>> 1fde21a (Docker compose deploy script to deploy with watchtower)
       - run: npm run build

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Emojive Backend
 
+![Update Docker Registry](https://github.com/thomasy314/emojive-backend/actions/workflows/node.js.yml/badge.svg)
+![Update Docker Registry](https://github.com/thomasy314/emojive-backend/actions/workflows/docker-build-and-push.yml/badge.svg)
+
 Emojive is a unique chat service where communication is exclusively through emojis. Users can either join or create a known chatroom or be randomly paired with another user. The random pairing feature is designed to connect people from different parts of the world, especially those who don't share a common language, fostering a universal and visually expressive form of communication.
 
 The full initial design doc for Emojive can be found [here](https://orchid-raft-257.notion.site/Emojive-2b8af8f7d1d1465f9149a1baa3523b8e?pvs=4)

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,16 @@
+services:
+  emojive-api:
+    image: thomasy314/emojive-backend:latest
+    container_name: emojive-api
+    environment:
+      - IP=${IP}
+      - PORT=${PORT}
+      - NODE_ENV=production
+    ports:
+      - ${PORT}:${PORT}
+  watchtower:
+    image: containrrr/watchtower
+    container_name: emojive-watchtower
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: --interval 30 --cleanup emojive-api


### PR DESCRIPTION
The new docker compose script will check for changes in the docker hub registry and automatically deploy using watcher tower.

This is used instead of github actions runner as using a self-hosted runner to deploy is [advised against in public repos](https://docs.github.com/en/actions/hosting-your-own-runners/managing-self-hosted-runners/about-self-hosted-runners#self-hosted-runner-security)

Adding badges to show current status of the two CI workflows to README