### PR TITLE
Adding chatroom api controller and create chatroom validator

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -24,14 +24,16 @@ const config: JestConfigWithTsJest = {
   collectCoverage: true,
 
   // An array of glob patterns indicating a set of files for which coverage information should be collected
+  // TODO: Implemnet Integration Tests
   collectCoverageFrom: [
     'src/**/*.ts',
     // Removing router related files as these are tested in integration tests
-    // TODO: Implemnet Integration Tests
     '!src/app.ts',
     '!src/**/*router.ts',
     '!src/**/*types.ts',
     '!src/config/express.config.ts',
+    // Since this is a personal project and creating unit tests for schema validators is time consuming, this will be skipped
+    '!src/**/*schema.ts',
   ],
 
   // The directory where Jest should output its coverage files

--- a/src/chatrooms/chatroom.controller.spec.ts
+++ b/src/chatrooms/chatroom.controller.spec.ts
@@ -1,0 +1,61 @@
+import { NextFunction, Request, Response } from 'express';
+import {
+  givenRandomBoolean,
+  givenRandomEmoji,
+  givenRandomInt,
+} from '../utils/test-helpers';
+import chatroomController from './chatrooms.controller';
+
+describe('Chatroom Controller', () => {
+  let response: Response;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    response = {} as Response;
+    response.send = jest.fn();
+
+    next = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Create Chatroom', () => {
+    test('GIVEN proper input THEN a chatroom is created and returned', async () => {
+      const chatroomName = givenRandomEmoji();
+      const isPublic = givenRandomBoolean();
+      const maxOccupancy = givenRandomInt();
+
+      // Setup
+      const request: Request = {
+        body: {
+          chatroomName,
+          isPublic,
+          maxOccupancy,
+        },
+      } as unknown as Request;
+
+      // Execute
+      await chatroomController().createChatroom(request, response, next);
+
+      // Validate
+
+      // TODO: Check if createChatroom called correct times and with correct input
+
+      expect(response.send).toHaveBeenCalledTimes(1);
+      expect(response.send).toHaveBeenCalledWith({
+        chatroomUUID: '123', // TODO: Change to random UUID
+        chatroomName,
+        isPublic,
+        maxOccupancy,
+      });
+
+      expect(next).toHaveBeenCalledTimes(0);
+    });
+
+    test.todo(
+      'GIVEN an error occurs during chatroom creation THEN an error is passed to next'
+    );
+  });
+});

--- a/src/chatrooms/chatrooms.controller.ts
+++ b/src/chatrooms/chatrooms.controller.ts
@@ -16,7 +16,7 @@ function chatroomController() {
       isPublic,
       maxOccupancy,
     });
-    return Promise.resolve();
+    return Promise.resolve().catch(next);
   }
 
   return {

--- a/src/chatrooms/chatrooms.controller.ts
+++ b/src/chatrooms/chatrooms.controller.ts
@@ -1,0 +1,27 @@
+import { NextFunction, Request, Response } from 'express';
+
+function chatroomController() {
+  function createChatroom(
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const { chatroomName, isPublic, maxOccupancy } = req.body;
+
+    // TODO: Call chatroomService().createChatroom
+
+    res.send({
+      chatroomUUID: '123', // TODO: Get UUID from createChatroom() call
+      chatroomName,
+      isPublic,
+      maxOccupancy,
+    });
+    return Promise.resolve();
+  }
+
+  return {
+    createChatroom,
+  };
+}
+
+export default chatroomController;

--- a/src/chatrooms/chatrooms.router.ts
+++ b/src/chatrooms/chatrooms.router.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import chatroomController from './chatrooms.controller';
+import { createCharoomValidator } from './validation/create-chatroom.schema';
+
+const chatroomRouter = Router();
+
+chatroomRouter.post(
+  '/create',
+  createCharoomValidator,
+  chatroomController().createChatroom
+);
+
+export default chatroomRouter;

--- a/src/chatrooms/validation/create-chatroom.schema.ts
+++ b/src/chatrooms/validation/create-chatroom.schema.ts
@@ -1,0 +1,53 @@
+import { JSONSchemaType } from 'ajv';
+import ajv from '../../middleware/validation/ajv';
+import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
+import createValidator from '../../middleware/validation/validator';
+
+type CreateChatroomSchema = {
+  chatroomName: string;
+  isPublic: boolean;
+  maxOccupancy: number;
+};
+
+const createChatroomScheam: JSONSchemaType<CreateChatroomSchema> = {
+  type: 'object',
+  properties: {
+    chatroomName: {
+      type: 'string',
+      format: 'emoji',
+      nullable: false,
+      minLength: 1,
+      maxLength: 10,
+      errorMessage: {
+        minLength: `${VALIDATION_ERRORS.MIN_LENGTH} 1 character`,
+        maxLength: `${VALIDATION_ERRORS.MAX_LENGTH} 10 characters - note that emojis can be made up of multiple characters`,
+        type: `${VALIDATION_ERRORS.TYPE} String`,
+        format: `${VALIDATION_ERRORS.FORMAT} Emoji`,
+      },
+    },
+    isPublic: {
+      type: 'boolean',
+      errorMessage: {
+        type: `${VALIDATION_ERRORS.TYPE} Boolean`,
+      },
+    },
+    maxOccupancy: {
+      type: 'number',
+      maximum: 10,
+      minimum: 2,
+      errorMessage: {
+        minimum: `${VALIDATION_ERRORS.MIN} 2`,
+        maximum: `${VALIDATION_ERRORS.MAX} 2`,
+        type: `${VALIDATION_ERRORS.TYPE} Number`,
+      },
+    },
+  },
+  required: ['chatroomName'],
+  additionalProperties: false,
+};
+
+const validateCreateChatroom = ajv.compile(createChatroomScheam);
+
+const createCharoomValidator = createValidator(validateCreateChatroom);
+
+export { createCharoomValidator };

--- a/src/middleware/validation/error-messages.ts
+++ b/src/middleware/validation/error-messages.ts
@@ -1,6 +1,8 @@
 const VALIDATION_ERRORS = {
   MIN_LENGTH: 'must contain at least',
   MAX_LENGTH: 'must contain at most',
+  MAX: 'must be less than',
+  MIN: 'must be more than',
   EXACT_LENGTH: `must contain exactly`,
   TYPE: 'must be of type',
   PATTERN: 'must match pattern',

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,4 +1,5 @@
 import express, { Express } from 'express';
+import chatroomRouter from '../chatrooms/chatrooms.router';
 import authorization from '../middleware/auth/authorization';
 import errorHandler from '../middleware/errorHandling/error-handler';
 import userRouter from '../users/users.router';
@@ -11,6 +12,7 @@ expressServer.use(express.json());
 expressServer.use(authorization);
 
 expressServer.use('/user', userRouter);
+expressServer.use('/chatroom', chatroomRouter);
 
 expressServer.use(errorHandler);
 

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -14,7 +14,7 @@ function userController() {
     return userService()
       .createUser(userName, languageTags, countryCode, countryRegion)
       .then(result => {
-        res.send(JSON.stringify(result));
+        res.send(result);
       })
       .catch(next);
   };

--- a/src/users/users.controllers.spec.ts
+++ b/src/users/users.controllers.spec.ts
@@ -70,7 +70,7 @@ describe('Users Controller', () => {
       );
 
       expect(response.send).toHaveBeenCalledTimes(1);
-      expect(response.send).toHaveBeenCalledWith(JSON.stringify(responseData));
+      expect(response.send).toHaveBeenCalledWith(responseData);
 
       expect(next).toHaveBeenCalledTimes(0);
     });

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -20,7 +20,7 @@ export function givenRandomBoolean(probablityOfTrue: number = 0.5): boolean {
 export function givenRandomEmoji(length: number = 1): string {
   return Array(length)
     .fill('')
-    .map(x => randomEmoji().emoji)
+    .map(() => randomEmoji().emoji)
     .join('');
 }
 

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -1,3 +1,4 @@
+import { random as randomEmoji } from 'node-emoji';
 import { LanguageTag } from '../languages/languages.types';
 
 export function givenValidUUID(): string {
@@ -12,11 +13,22 @@ export function givenRandomInt(max: number = 100): number {
   return Math.floor(Math.random() * max);
 }
 
+export function givenRandomBoolean(probablityOfTrue: number = 0.5): boolean {
+  return Math.random() < probablityOfTrue;
+}
+
+export function givenRandomEmoji(length: number = 1): string {
+  return Array(length)
+    .fill('')
+    .map(x => randomEmoji().emoji)
+    .join('');
+}
+
 export function givenDBUser() {
   return {
     user_id: 1,
     user_uuid: '7ab39ec9-612d-4be8-b43c-f84bbea7f8a4',
-    user_name: '🦆',
+    user_name: givenRandomEmoji(),
     creation_timestamp: '2024-09-12T23:40:02.679Z',
     last_activity_time: '2024-09-12T23:40:02.679Z',
     country: 'US',


### PR DESCRIPTION
## Chatrooms
- Adding router controller for managing and handling chatroom api requests
- TODO: create chatroom service which handles actual business logic

## Bug Fixes
- Changes response for users and chatroom apis to return JSON object instead of stringified JSON as this was not needed and made it harder to access data.

## Tests
- Removing schema files from needing unit tests. This would be nice to have, however, due to the time it takes to create them and the fact that this is a personal project, I am deciding to not add these. You can see what these tests would look like by looking at the create user validator
- Added a few more test helper functions