### PR TITLE
Adding support for kafka pub/sub

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,13 @@ The frontend portion of this project is located in the [emojive-frontend](https:
 
 ## Environment Variables
 
-| Name              | Description                                     | Default Value |
-| ----------------- | ----------------------------------------------- | ------------- |
-| PORT              | PORT the server listens on                      | `3000`        |
-| IP                | IP the server listens on                        | `localhost`   |
-| POSTGRES_USER     | Username used to connect to PostgreSQL server   |               |
-| POSTGRES_PASSWORD | Password used to connect to PostgreSQL server   |               |
-| POSTGRES_PORT     | Port exposed to API to access PostgreSQL Server |               |
-| POSTGRES_DB       | Name given to Emojive PostreSQL database        |               |
+| Name              | Description                                   | Default Value |
+| ----------------- | --------------------------------------------- | ------------- |
+| PORT              | PORT the server listens on                    | `3000`        |
+| IP                | IP the server listens on                      | `localhost`   |
+| POSTGRES_USER     | Username used to connect to PostgreSQL server |               |
+| POSTGRES_PASSWORD | Password used to connect to PostgreSQL server |               |
+| POSTGRES_DB       | Name given to Emojive PostreSQL database      |               |
 
 ## Prerequisites
 

--- a/compose.core.yml
+++ b/compose.core.yml
@@ -6,7 +6,7 @@ services:
       - PORT=${PORT}
 
       - POSTGRES_HOST=postgres_db
-      - POSTGRES_PORT=${POSTGRES_PORT}
+      - POSTGRES_PORT=5432
       - POSTGRES_USER=${POSTGRES_USER}
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
       - POSTGRES_DB=${POSTGRES_DB}
@@ -15,8 +15,11 @@ services:
     depends_on:
       postgres_db:
         condition: service_healthy
+      kafka_events:
+        condition: service_healthy
     networks:
       - postgres_network
+      - kafka_network
 
   postgres_db:
     container_name: emojive-db
@@ -37,6 +40,31 @@ services:
     networks:
       - postgres_network
 
+  kafka_events:
+    container_name: emojive-events
+    image: 'bitnami/kafka:latest'
+    restart: always
+    environment:
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka_events:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          '/opt/bitnami/kafka/bin/kafka-topics.sh --bootstrap-server 127.0.0.1:9092 --list || exit 1',
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 10
+    networks:
+      - kafka_network
+
 networks:
   postgres_network:
+    driver: bridge
+  kafka_network:
     driver: bridge

--- a/compose.prod.deploy.yml
+++ b/compose.prod.deploy.yml
@@ -13,8 +13,15 @@ services:
   postgres_db:
     container_name: emojive-db
     volumes:
-      - pgdata:/var/lib/postgresql/data
+      - postgres_data:/var/lib/postgresql/data
+
+  kafka_events:
+    container_name: emojive-events
+    volumes:
+      - kafka_data:/bitnami/kafka
 
 volumes:
-  pgdata:
+  postgres_data:
+    driver: local
+  kafka_data:
     driver: local

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "ajv-errors": "^3.0.0",
         "ajv-formats": "^3.0.1",
         "express": "^4.21.0",
+        "kafkajs": "^2.2.4",
         "language-tags": "^1.0.9",
         "node-emoji": "^2.1.3",
         "pg": "^8.12.0",
@@ -5237,6 +5238,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kafkajs": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/kafkajs/-/kafkajs-2.2.4.tgz",
+      "integrity": "sha512-j/YeapB1vfPT2iOIUn/vxdyKEuhuY2PxMBvf5JWux6iSaukAccrMtXEY/Lb7OvavDhOWME589bpLrEdnVHjfjA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ajv-errors": "^3.0.0",
     "ajv-formats": "^3.0.1",
     "express": "^4.21.0",
+    "kafkajs": "^2.2.4",
     "language-tags": "^1.0.9",
     "node-emoji": "^2.1.3",
     "pg": "^8.12.0",

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -1,0 +1,29 @@
+interface EventAdmin {
+  createTopic: (topic: string, numPartitions: number) => Promise<void>;
+  destroy: () => Promise<void>;
+}
+
+type EventConsumerHandler = (eventMessage: EventBusEvent) => void;
+
+interface EventConsumer {
+  setEventHandler: (eventHandler: EventConsumerHandler) => Promise<void>;
+  destroy: () => Promise<void>;
+}
+
+interface EventBusEvent {
+  key: string;
+  value: Object | null;
+}
+
+interface EventProducer {
+  sendMessage: (...events: EventBusEvent[]) => Promise<void>;
+  destroy: () => Promise<void>;
+}
+
+export type {
+  EventAdmin,
+  EventBusEvent,
+  EventConsumer,
+  EventConsumerHandler,
+  EventProducer,
+};

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -12,7 +12,7 @@ interface EventConsumer {
 
 interface EventBusEvent {
   key: string;
-  value: Object | null;
+  value: object | null;
 }
 
 interface EventProducer {

--- a/src/events/kafka/index.spec.ts
+++ b/src/events/kafka/index.spec.ts
@@ -1,0 +1,28 @@
+import { Kafka } from 'kafkajs';
+import kafkaEvents from '.';
+
+describe('Kafka Client', () => {
+  beforeEach(() => {
+    kafkaEvents.destroy();
+  });
+
+  test('GIVEN kafka client has been set THEN get kafka returns client', () => {
+    // Setup
+    const kafkaClient = {} as Kafka;
+
+    // Set Kafka Client
+    kafkaEvents.initKafka(kafkaClient);
+
+    // Get Kafka Client
+    const returnedKafkaClient = kafkaEvents.getKafka();
+
+    // Validate
+    expect(kafkaClient).toBe(returnedKafkaClient);
+  });
+
+  test('GIVEN kafka client has NOT been set THEN get kafka throws error', () => {
+    expect(kafkaEvents.getKafka).toThrow(
+      'kafka client is undefined, please initialize with initKafka(kafkaClient: Kafka)'
+    );
+  });
+});

--- a/src/events/kafka/index.ts
+++ b/src/events/kafka/index.ts
@@ -1,0 +1,30 @@
+import { Kafka } from 'kafkajs';
+
+function kafkaEvents() {
+  let kafkaClient: Kafka | undefined;
+
+  function initKafka(initClient: Kafka) {
+    kafkaClient = initClient;
+  }
+
+  function getKafka(): Kafka {
+    if (kafkaClient === undefined) {
+      throw new Error(
+        'kafka client is undefined, please initialize with initKafka(kafkaClient: Kafka)'
+      );
+    }
+    return kafkaClient;
+  }
+
+  function destroy() {
+    kafkaClient = undefined;
+  }
+
+  return {
+    initKafka,
+    getKafka,
+    destroy,
+  };
+}
+
+export default kafkaEvents();

--- a/src/events/kafka/kafka.admin.spec.ts
+++ b/src/events/kafka/kafka.admin.spec.ts
@@ -1,0 +1,68 @@
+import { Admin, Kafka } from 'kafkajs';
+import { givenRandomString } from '../../utils/test-helpers';
+import { EventAdmin } from '../events.types';
+import createKafkaAdmin from './kafka.admin';
+
+describe('Events Admin', () => {
+  const kafkaAdmin = {} as Admin;
+  kafkaAdmin.connect = jest.fn();
+  kafkaAdmin.createTopics = jest.fn();
+  kafkaAdmin.disconnect = jest.fn();
+
+  const kafka = {} as Kafka;
+  kafka.admin = jest.fn(() => kafkaAdmin);
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  describe('Create Kafka Admin', () => {
+    test('GIVEN kafka client THEN event admin is created', async () => {
+      // Execute
+      const eventAdmin: EventAdmin = await createKafkaAdmin(kafka);
+
+      // Validate
+      expect(kafkaAdmin.connect).toHaveBeenCalledTimes(1);
+
+      expect(eventAdmin).toHaveProperty('createTopic');
+      expect(eventAdmin).toHaveProperty('destroy');
+    });
+  });
+
+  describe('Create Topic', () => {
+    test('GIVEN a call to createTopic THEN kafka admin should be called with correct input', async () => {
+      // Setup
+      const eventAdmin: EventAdmin = await createKafkaAdmin(kafka);
+
+      const topic = givenRandomString();
+      const numPartitions = 1;
+
+      // Execute
+      eventAdmin.createTopic(topic, numPartitions);
+
+      // Validate
+      expect(kafkaAdmin.createTopics).toHaveBeenCalledTimes(1);
+      expect(kafkaAdmin.createTopics).toHaveBeenCalledWith({
+        topics: [
+          {
+            topic,
+            numPartitions,
+          },
+        ],
+      });
+    });
+  });
+
+  describe('Destroy', () => {
+    test('GIVEN destroy function called THEN kafka consumer is disconnected', async () => {
+      // Setup
+      const eventAdmin: EventAdmin = await createKafkaAdmin(kafka);
+
+      // Execute
+      eventAdmin.destroy();
+
+      // Validate
+      expect(kafkaAdmin.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/events/kafka/kafka.admin.ts
+++ b/src/events/kafka/kafka.admin.ts
@@ -1,0 +1,27 @@
+import { Kafka } from 'kafkajs';
+import { EventAdmin } from '../events.types';
+
+async function createKafkaAdmin(kafka: Kafka): Promise<EventAdmin> {
+  const admin = kafka.admin();
+
+  await admin.connect();
+
+  async function createTopic(topic: string, numPartitions: number) {
+    await admin.createTopics({
+      topics: [
+        {
+          topic,
+          numPartitions,
+        },
+      ],
+    });
+  }
+
+  async function destroy(): Promise<void> {
+    await admin.disconnect();
+  }
+
+  return { createTopic, destroy };
+}
+
+export default createKafkaAdmin;

--- a/src/events/kafka/kafka.consumer.spec.ts
+++ b/src/events/kafka/kafka.consumer.spec.ts
@@ -1,0 +1,198 @@
+import { Consumer, EachMessagePayload, Kafka, KafkaMessage } from 'kafkajs';
+import {
+  givenRandomInt,
+  givenRandomJson,
+  givenRandomString,
+} from '../../utils/test-helpers';
+import { EventConsumer } from '../events.types';
+import createKafkaConsumer from './kafka.consumer';
+
+describe('Events Consumer', () => {
+  const kafkaConsumer = {} as Consumer;
+  kafkaConsumer.connect = jest.fn();
+  kafkaConsumer.subscribe = jest.fn();
+  kafkaConsumer.run = jest.fn();
+  kafkaConsumer.disconnect = jest.fn();
+
+  const kafka = {} as Kafka;
+  kafka.consumer = jest.fn(() => kafkaConsumer);
+
+  let groupId: string;
+  let topics: string[];
+
+  beforeEach(() => {
+    groupId = givenRandomString();
+    topics = [givenRandomString()];
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  describe('Create Kafka Consumer', () => {
+    test('GIVEN kafka client and consumer config THEN event consumer is created', async () => {
+      // Setup
+
+      // Execute
+      const eventConsumer: EventConsumer = await createKafkaConsumer(
+        kafka,
+        groupId,
+        topics
+      );
+
+      // Validate
+      expect(kafkaConsumer.connect).toHaveBeenCalledTimes(1);
+
+      expect(eventConsumer).toHaveProperty('setEventHandler');
+      expect(eventConsumer).toHaveProperty('destroy');
+    });
+  });
+
+  describe('Set Event Handler', () => {
+    test('GIVEN an event handler THEN handler should be called when message received', async () => {
+      // Setup
+      const eventConsumer = await createKafkaConsumer(kafka, groupId, topics);
+
+      const eventConumerHandler = jest.fn();
+
+      const kafkaConsumerRunMock = jest.mocked(kafkaConsumer.run);
+
+      const consoleLogSpy = jest.spyOn(console, 'log');
+      consoleLogSpy.mockImplementation(jest.fn());
+
+      const partition = givenRandomInt();
+      const messageKey = givenRandomString();
+      const messageValue = givenRandomJson();
+      const message = {
+        key: messageKey,
+        value: JSON.stringify(messageValue),
+      } as unknown as KafkaMessage;
+      const eachMessagePayload: EachMessagePayload = {
+        topic: topics[0],
+        partition,
+        message,
+        heartbeat: jest.fn(),
+        pause: jest.fn(),
+      };
+
+      // Execute
+      eventConsumer.setEventHandler(eventConumerHandler);
+
+      // Validate
+      const eachMessagHandler =
+        kafkaConsumerRunMock.mock.calls[0][0]?.eachMessage;
+      if (eachMessagHandler == undefined) {
+        throw new Error('each message payload is undefined');
+      }
+
+      eachMessagHandler(eachMessagePayload);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        `${groupId}: [${topics[0]}]: PART:${partition}`,
+        {
+          key: messageKey,
+          value: messageValue,
+        }
+      );
+    });
+
+    test('GIVEN an event handler THEN handler should be called when message received', async () => {
+      // Setup
+      const eventConsumer = await createKafkaConsumer(kafka, groupId, topics);
+
+      const eventConumerHandler = jest.fn();
+
+      const kafkaConsumerRunMock = jest.mocked(kafkaConsumer.run);
+
+      const consoleLogSpy = jest.spyOn(console, 'log');
+      consoleLogSpy.mockImplementation(jest.fn());
+
+      const partition = givenRandomInt();
+      const messageKey = givenRandomString();
+      const message = {
+        key: messageKey,
+        value: null,
+      } as unknown as KafkaMessage;
+      const eachMessagePayload: EachMessagePayload = {
+        topic: topics[0],
+        partition,
+        message,
+        heartbeat: jest.fn(),
+        pause: jest.fn(),
+      };
+
+      // Execute
+      eventConsumer.setEventHandler(eventConumerHandler);
+
+      // Validate
+      const eachMessagHandler =
+        kafkaConsumerRunMock.mock.calls[0][0]?.eachMessage;
+      if (eachMessagHandler == undefined) {
+        throw new Error('each message payload is undefined');
+      }
+
+      eachMessagHandler(eachMessagePayload);
+
+      expect(consoleLogSpy).toHaveBeenCalledWith(
+        `${groupId}: [${topics[0]}]: PART:${partition}`,
+        {
+          key: messageKey,
+          value: null,
+        }
+      );
+    });
+
+    test('GIVEN an event handler with no key THEN error should be thrown', async () => {
+      // Setup
+      const eventConsumer = await createKafkaConsumer(kafka, groupId, topics);
+
+      const eventConumerHandler = jest.fn();
+
+      const kafkaConsumerRunMock = jest.mocked(kafkaConsumer.run);
+
+      const partition = givenRandomInt();
+      const messageValue = givenRandomJson();
+      const message = {
+        key: null,
+        value: JSON.stringify(messageValue),
+      } as unknown as KafkaMessage;
+      const eachMessagePayload: EachMessagePayload = {
+        topic: topics[0],
+        partition,
+        message,
+        heartbeat: jest.fn(),
+        pause: jest.fn(),
+      };
+
+      // Execute
+      eventConsumer.setEventHandler(eventConumerHandler);
+
+      // Validate
+      const eachMessagHandler =
+        kafkaConsumerRunMock.mock.calls[0][0]?.eachMessage;
+      if (eachMessagHandler == undefined) {
+        throw new Error('each message payload is undefined');
+      }
+
+      expect(() => eachMessagHandler(eachMessagePayload)).rejects.toStrictEqual(
+        new Error(
+          `${groupId}: [${topics[0]}]: PART:${partition} - Message Missing Key`,
+          { cause: message }
+        )
+      );
+    });
+  });
+
+  describe('Destroy', () => {
+    test('GIVEN destroy function called THEN kafka consumer is disconnected', async () => {
+      // Setup
+      const eventConsumer = await createKafkaConsumer(kafka, groupId, topics);
+
+      // Execute
+      eventConsumer.destroy();
+
+      // Validate
+      expect(kafkaConsumer.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/events/kafka/kafka.consumer.ts
+++ b/src/events/kafka/kafka.consumer.ts
@@ -1,0 +1,58 @@
+import { Kafka } from 'kafkajs';
+import {
+  EventBusEvent,
+  EventConsumer,
+  EventConsumerHandler,
+} from '../events.types';
+
+async function createKafkaConsumer(
+  kafka: Kafka,
+  groupId: string,
+  topics: string[]
+): Promise<EventConsumer> {
+  const consumer = kafka.consumer({ groupId });
+
+  await consumer.connect();
+
+  await consumer.subscribe({
+    topics: topics,
+    fromBeginning: true,
+  });
+
+  async function setEventHandler(
+    eventHandler: EventConsumerHandler
+  ): Promise<void> {
+    await consumer.run({
+      eachMessage: async ({ topic, partition, message }) => {
+        const { key, value } = message;
+
+        if (key == null || key == undefined) {
+          throw new Error(
+            `${groupId}: [${topic}]: PART:${partition} - Message Missing Key`,
+            { cause: message }
+          );
+        }
+
+        const busEvent: EventBusEvent = {
+          key: key.toString(),
+          value: value ? JSON.parse(value.toString()) : null,
+        };
+
+        console.log(`${groupId}: [${topic}]: PART:${partition}`, busEvent);
+
+        eventHandler(busEvent);
+      },
+    });
+  }
+
+  async function destroy(): Promise<void> {
+    await consumer.disconnect();
+  }
+
+  return {
+    setEventHandler,
+    destroy,
+  };
+}
+
+export default createKafkaConsumer;

--- a/src/events/kafka/kafka.producer.spec.ts
+++ b/src/events/kafka/kafka.producer.spec.ts
@@ -1,0 +1,86 @@
+import { Kafka, Producer } from 'kafkajs';
+import { givenRandomJson, givenRandomString } from '../../utils/test-helpers';
+import { EventBusEvent, EventProducer } from '../events.types';
+import createKafkaProducer from './kakfa.producer';
+
+describe('Events Producer', () => {
+  const kafkaProducer = {} as Producer;
+  kafkaProducer.connect = jest.fn();
+  kafkaProducer.send = jest.fn();
+  kafkaProducer.disconnect = jest.fn();
+
+  const kafka = {} as Kafka;
+  kafka.producer = jest.fn(() => kafkaProducer);
+
+  let topic: string;
+
+  beforeEach(() => {
+    topic = givenRandomString();
+  });
+
+  afterEach(async () => {
+    jest.clearAllMocks();
+  });
+
+  describe('Create Kafka Producer', () => {
+    test('GIVEN kafka client THEN event producer is created', async () => {
+      // Execute
+      const eventProducer: EventProducer = await createKafkaProducer(
+        kafka,
+        topic
+      );
+
+      // Validate
+      expect(kafkaProducer.connect).toHaveBeenCalledTimes(1);
+
+      expect(eventProducer).toHaveProperty('sendMessage');
+      expect(eventProducer).toHaveProperty('destroy');
+    });
+  });
+
+  describe('Send Message', () => {
+    test('GIVEN a producer event THEN kafka producer call send with format message', async () => {
+      // Setup
+      const eventProducer: EventProducer = await createKafkaProducer(
+        kafka,
+        topic
+      );
+
+      const producerEvent: EventBusEvent = {
+        key: givenRandomString(),
+        value: givenRandomJson(),
+      };
+
+      // Execute
+      eventProducer.sendMessage(producerEvent);
+
+      // Validate
+      expect(kafkaProducer.send).toHaveBeenCalledTimes(1);
+      expect(kafkaProducer.send).toHaveBeenCalledWith({
+        topic,
+        messages: [
+          {
+            key: producerEvent.key,
+            value: JSON.stringify(producerEvent.value),
+          },
+        ],
+      });
+    });
+  });
+
+  describe('Destroy', () => {
+    test('GIVEN destroy function called THEN kafka producer is disconnected', async () => {
+      // Setup
+      const eventProducer: EventProducer = await createKafkaProducer(
+        kafka,
+        topic
+      );
+
+      // Execute
+      eventProducer.destroy();
+
+      // Validate
+      expect(kafkaProducer.disconnect).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/events/kafka/kakfa.producer.ts
+++ b/src/events/kafka/kakfa.producer.ts
@@ -1,0 +1,36 @@
+import { Kafka, Message } from 'kafkajs';
+import { EventBusEvent, EventProducer } from '../events.types';
+
+async function createKafkaProducer(
+  kafka: Kafka,
+  topic: string
+): Promise<EventProducer> {
+  const producer = kafka.producer();
+
+  await producer.connect();
+
+  async function sendMessage(...events: EventBusEvent[]): Promise<void> {
+    const messages = events.map((event): Message => {
+      return {
+        key: event.key,
+        value: JSON.stringify(event.value),
+      };
+    });
+
+    await producer.send({
+      topic,
+      messages,
+    });
+  }
+
+  async function destroy(): Promise<void> {
+    await producer.disconnect();
+  }
+
+  return {
+    sendMessage,
+    destroy,
+  };
+}
+
+export default createKafkaProducer;


### PR DESCRIPTION
## Event System (Kafka)
- Adding support for an event bus that will allow for each server handling chat messages to publish and consume messages related to the chatroom their client is connected to
- Added Kafka to docker compose file
- Created three modules for managing events:
    - Admin: Control plane actions like adding topics and partitions
    - Producer: Adding messages to the event bus
    - Consumer: Ingesting messages from event bus

## Docker
- Removed Port environment variable as this shouldn't need dynamic configuration, similar to the kafka instances