### PR TITLE
Stop joining chatroom if user or chatroom UUID doesn't exist

### DIFF
--- a/src/chatrooms/db/chatrooms.queries.ts
+++ b/src/chatrooms/db/chatrooms.queries.ts
@@ -22,13 +22,18 @@ async function createChatroomUserLinkQuery(
   const values = [chatroomUUID, userUUID];
 
   try {
-    await query(queryText, values);
-  } catch (error) {
-    // @ts-expect-error - error is a pg error
-    if (error.code !== '23505') {
-      throw error;
+    const result = await query(queryText, values);
+    if (result.rowCount === 0) {
+      throw Error(
+        `Chatroom or user not found for UUIDs: chatroom::${chatroomUUID}, user::${userUUID}`
+      );
     }
-    console.error(error);
+  } catch (error) {
+    if ((error as { code: string }).code === '23505') {
+      console.error(error);
+      return;
+    }
+    throw error;
   }
 }
 

--- a/src/websocket/websocket-middleware-handler.spec.ts
+++ b/src/websocket/websocket-middleware-handler.spec.ts
@@ -115,29 +115,57 @@ describe('WebSocket Middleware Handler', () => {
     expect(socket.close).toHaveBeenCalledTimes(0);
   });
 
-  test('GIVEN error passed to next THEN error handler called', () => {
-    // Setup
+  describe('Error Handling', () => {
+    test('GIVEN error passed to next THEN error handler called', () => {
+      // Setup
 
-    const error = givenRandomError();
-    const middleware1 = jest.fn((socket, context, next) => next({ error }));
-    const middleware2 = jest.fn((socket, context, next) => next({ error }));
+      const error = givenRandomError();
+      const middleware1 = jest.fn((socket, context, next) => next({ error }));
+      const middleware2 = jest.fn();
 
-    const middlewareHandler = websocketMiddlewareHandler(
-      middleware1,
-      middleware2
-    );
+      const middlewareHandler = websocketMiddlewareHandler(
+        middleware1,
+        middleware2
+      );
 
-    const socket = {} as WebSocket;
-    socket.close = jest.fn();
-    const context: string[] = [];
+      const socket = {} as WebSocket;
+      socket.close = jest.fn();
+      const context: string[] = [];
 
-    // Execute
-    middlewareHandler.handle(socket, context);
+      // Execute
+      middlewareHandler.handle(socket, context);
 
-    // Validate
-    expect(websocketErrorHandlerMock).toHaveBeenCalledTimes(1);
-    expect(websocketErrorHandlerMock).toHaveBeenCalledWith(error, socket);
+      // Validate
+      expect(websocketErrorHandlerMock).toHaveBeenCalledTimes(1);
+      expect(websocketErrorHandlerMock).toHaveBeenCalledWith(error, socket);
 
-    expect(middleware2).toHaveBeenCalledTimes(0);
+      expect(middleware2).toHaveBeenCalledTimes(0);
+    });
+
+    test('GIVEN error passed to next THEN error handler called', () => {
+      // Setup
+
+      const error = givenRandomError();
+      const middleware1 = jest.fn((socket, context, next) => next(error));
+      const middleware2 = jest.fn();
+
+      const middlewareHandler = websocketMiddlewareHandler(
+        middleware1,
+        middleware2
+      );
+
+      const socket = {} as WebSocket;
+      socket.close = jest.fn();
+      const context: string[] = [];
+
+      // Execute
+      middlewareHandler.handle(socket, context);
+
+      // Validate
+      expect(websocketErrorHandlerMock).toHaveBeenCalledTimes(1);
+      expect(websocketErrorHandlerMock).toHaveBeenCalledWith(error, socket);
+
+      expect(middleware2).toHaveBeenCalledTimes(0);
+    });
   });
 });

--- a/src/websocket/websocket-middleware-handler.ts
+++ b/src/websocket/websocket-middleware-handler.ts
@@ -44,18 +44,21 @@ function websocketMiddlewareHandler(...middlewares: WebSocketRouterFunction[]) {
       // TODO: Allow for custom error handler
       if (middleware) {
         try {
-          middleware(
-            socket,
-            context,
-            ({ error, newContext }: NextProps = {}) => {
-              if (error) {
-                websocketErrorHandler(error, socket);
-                return;
-              }
-              context = newContext ?? context;
-              runner(index + 1);
+          middleware(socket, context, (input = {}) => {
+            if (input instanceof Error) {
+              websocketErrorHandler(input, socket);
+              return;
             }
-          );
+
+            const { error, newContext } = input;
+
+            if (error) {
+              websocketErrorHandler(error, socket);
+              return;
+            }
+            context = newContext ?? context;
+            runner(index + 1);
+          });
         } catch (err) {
           if (err instanceof Error) {
             websocketErrorHandler(err, socket);


### PR DESCRIPTION
Fixing issue where users are able to connect even if the provided userUUID and/or chatroomUUID are undefined