### PR TITLE
UserUUID is supplied through auth header instead of body

### DIFF
--- a/src/chatrooms/chatrooms.router.ts
+++ b/src/chatrooms/chatrooms.router.ts
@@ -7,7 +7,7 @@ import { leaveChatroomValidator } from './validation/leave-chatroom.schema';
 import { receiveChatroomMessageValidator } from './validation/receive-chatroom-message.schema';
 
 const chatroomRouter = Router();
-const chatromoWebSocketRouter = websocketRouter();
+const chatroomWebSocketRouter = websocketRouter();
 
 chatroomRouter.post(
   '/create',
@@ -15,22 +15,22 @@ chatroomRouter.post(
   chatroomController.createChatroom
 );
 
-chatromoWebSocketRouter.onWebSocketConnection(
+chatroomWebSocketRouter.onWebSocketConnection(
   '/',
   joinCharoomValidator,
   chatroomController.joinChatroom
 );
 
-chatromoWebSocketRouter.onWebSocketMessage(
+chatroomWebSocketRouter.onWebSocketMessage(
   '/',
   receiveChatroomMessageValidator,
   chatroomController.receiveChatroomMessage
 );
 
-chatromoWebSocketRouter.onWebSocketClose(
+chatroomWebSocketRouter.onWebSocketClose(
   '/',
   leaveChatroomValidator,
   chatroomController.leaveChatroom
 );
 
-export { chatromoWebSocketRouter, chatroomRouter };
+export { chatroomRouter, chatroomWebSocketRouter };

--- a/src/chatrooms/validation/join-chatroom.schema.ts
+++ b/src/chatrooms/validation/join-chatroom.schema.ts
@@ -3,6 +3,7 @@ import ajv from '../../middleware/validation/ajv';
 import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
   getConnectionParamContextData,
+  getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
 
 type JoinChatroomSchema = {
@@ -40,6 +41,7 @@ const validateCreateChatroom = ajv.compile(joinChatroomSchema);
 
 const joinCharoomValidator = createWebSocketValidator(
   validateCreateChatroom,
+  getConnectionUserUUIDContextData,
   getConnectionParamContextData
 );
 

--- a/src/chatrooms/validation/leave-chatroom.schema.ts
+++ b/src/chatrooms/validation/leave-chatroom.schema.ts
@@ -4,6 +4,7 @@ import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
   getConnectionCloseContextData,
   getConnectionParamContextData,
+  getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
 
 type LeaveChatroomSchema = {
@@ -58,6 +59,7 @@ const validateCreateChatroom = ajv.compile(leaveChatroomSchema);
 
 const leaveChatroomValidator = createWebSocketValidator(
   validateCreateChatroom,
+  getConnectionUserUUIDContextData,
   getConnectionParamContextData,
   getConnectionCloseContextData
 );

--- a/src/chatrooms/validation/receive-chatroom-message.schema.ts
+++ b/src/chatrooms/validation/receive-chatroom-message.schema.ts
@@ -5,6 +5,7 @@ import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
   getConnectionMessageContextData,
   getConnectionParamContextData,
+  getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
 
 type ReceiveChatroomMessageSchema = {
@@ -90,6 +91,7 @@ const validateReceiveChatroomMessage = ajv.compile(
 
 const receiveChatroomMessageValidator = createWebSocketValidator(
   validateReceiveChatroomMessage,
+  getConnectionUserUUIDContextData,
   getConnectionParamContextData,
   getConnectionMessageContextData
 );

--- a/src/middleware/auth/express.authorization.spec.ts
+++ b/src/middleware/auth/express.authorization.spec.ts
@@ -1,55 +1,47 @@
 import { NextFunction, Request, Response } from 'express';
 import authService from '../../auth/auth.service';
-import {
-  givenInvalidUUID,
-  givenRandomInt,
-  givenValidUUID,
-} from '../../utils/test-helpers';
+import { givenRandomString, givenValidUUID } from '../../utils/test-helpers';
 import { ResponseError } from '../errorHandling/error.types';
-import authorization from './authorization';
+import authorization from './express.authorization';
 
 const nonAllowListedUrl = '/non/allow-listed/api';
 
-jest.mock('../../auth/auth.service', () => {
-  const userServiceMock = {
-    confirmRouteAuthNeeded: jest.fn(),
-    authorizeRequest: jest.fn(),
-  };
-  return jest.fn(() => userServiceMock);
-});
+jest.mock('../../auth/auth.service');
 
 describe('authorization middleware', () => {
   const response: Response = {} as Response;
-  const authorizeRequestMock = jest.mocked(authService().authorizeRequest);
+  const authorizeRequestMock = jest.mocked(authService.authorizeRequest);
+  const getAuthTokenMock = jest.mocked(authService.getAuthToken);
   let next: NextFunction;
+  let authToken: string;
 
   beforeEach(() => {
     next = jest.fn();
+
+    authToken = givenRandomString();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
     authorizeRequestMock.mockReset();
+    getAuthTokenMock.mockReset();
   });
 
   test('GIVEN userUUID THEN authorization calls next function with no input', async () => {
     // Setup
-    const validUUID = givenValidUUID();
     const request: Request = {
       path: nonAllowListedUrl,
-      query: {
-        userUUID: validUUID,
-      },
     } as unknown as Request;
 
     authorizeRequestMock.mockResolvedValueOnce(true);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
 
     // Execute
     await authorization(request, response, next);
 
     // Validate
     expect(authorizeRequestMock).toHaveBeenCalledTimes(1);
-    expect(authorizeRequestMock).toHaveBeenCalledWith(validUUID);
+    expect(authorizeRequestMock).toHaveBeenCalledWith(authToken);
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith();
@@ -57,12 +49,8 @@ describe('authorization middleware', () => {
 
   test('GIVEN unauthorized userUUID THEN next function is called with response error', async () => {
     // Setup
-    const validUUID = givenValidUUID();
     const request: Request = {
       path: nonAllowListedUrl,
-      query: {
-        userUUID: validUUID,
-      },
     } as unknown as Request;
 
     const nextError: ResponseError = {
@@ -71,13 +59,14 @@ describe('authorization middleware', () => {
     };
 
     authorizeRequestMock.mockResolvedValueOnce(false);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
 
     // Execute
     await authorization(request, response, next);
 
     // Validate
     expect(authorizeRequestMock).toHaveBeenCalledTimes(1);
-    expect(authorizeRequestMock).toHaveBeenCalledWith(validUUID);
+    expect(authorizeRequestMock).toHaveBeenCalledWith(authToken);
 
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith(nextError);
@@ -90,9 +79,10 @@ describe('authorization middleware', () => {
     } as Request;
 
     authorizeRequestMock.mockResolvedValueOnce(true);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
 
     const confirmRouteAuthNeeded = jest.mocked(
-      authService().confirmRouteAuthNeeded
+      authService.confirmRouteAuthNeeded
     );
     confirmRouteAuthNeeded.mockReturnValueOnce(false);
 
@@ -104,52 +94,6 @@ describe('authorization middleware', () => {
     expect(next).toHaveBeenCalledWith();
 
     expect(authorizeRequestMock).toHaveBeenCalledTimes(0);
-  });
-
-  test('GIVEN non string userUUID THEN next function is called with response error', async () => {
-    // Setup
-
-    const request: Request = {
-      path: nonAllowListedUrl,
-      query: {
-        userUUID: givenRandomInt(),
-      },
-    } as unknown as Request;
-
-    const nextError: ResponseError = {
-      status: 401,
-      error: new Error('Not Authorized'),
-    };
-
-    // Execute
-    await authorization(request, response, next);
-
-    // Validate
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(next).toHaveBeenCalledWith(nextError);
-  });
-
-  test('GIVEN invalid UUID THEN next function is called with response error', async () => {
-    // Setup
-
-    const request: Request = {
-      path: nonAllowListedUrl,
-      query: {
-        userUUID: givenInvalidUUID(),
-      },
-    } as unknown as Request;
-
-    const nextError: ResponseError = {
-      status: 401,
-      error: new Error('Not Authorized'),
-    };
-
-    // Execute
-    await authorization(request, response, next);
-
-    // Validate
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(next).toHaveBeenCalledWith(nextError);
   });
 
   test('GIVEN auth service fails THEN next function is called with response error', async () => {
@@ -167,11 +111,38 @@ describe('authorization middleware', () => {
     };
 
     authorizeRequestMock.mockRejectedValueOnce(noUserFoundResError);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
 
     // Execute
     await authorization(request, response, next);
 
     // Validate
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(noUserFoundResError);
+  });
+
+  test('GIVEN get auth token fails THEN next function is called with response error', async () => {
+    // Setup
+    const request: Request = {
+      path: nonAllowListedUrl,
+      query: {
+        userUUID: givenValidUUID(),
+      },
+    } as unknown as Request;
+
+    getAuthTokenMock.mockImplementationOnce(() => {
+      throw new Error('User not found');
+    });
+
+    // Execute
+    await authorization(request, response, next);
+
+    // Validate
+    const noUserFoundResError: ResponseError = {
+      status: 401,
+      error: Error('User not found'),
+    };
+
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith(noUserFoundResError);
   });

--- a/src/middleware/auth/websocket.authorization.spec.ts
+++ b/src/middleware/auth/websocket.authorization.spec.ts
@@ -1,0 +1,199 @@
+import { WebSocket } from 'ws';
+import authService from '../../auth/auth.service';
+import { givenRandomString } from '../../utils/test-helpers';
+import webSocketCloseCode from '../../websocket/websocket-close-codes';
+import { ResponseError } from '../errorHandling/error.types';
+import websocketAuthorization from './websocket.authorization';
+
+const nonAllowListedUrl = '/non/allow-listed/api';
+
+jest.mock('../../auth/auth.service');
+
+describe('authorization middleware', () => {
+  const socket = {} as WebSocket;
+  const next = jest.fn();
+
+  const authorizeRequestMock = jest.mocked(authService.authorizeRequest);
+  const getAuthTokenMock = jest.mocked(authService.getAuthToken);
+  let authToken: string;
+
+  beforeEach(() => {
+    authToken = givenRandomString();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+    authorizeRequestMock.mockReset();
+    getAuthTokenMock.mockReset();
+  });
+
+  test('GIVEN userUUID THEN authorization calls next function with userUUID added to context', async () => {
+    // Setup
+    authorizeRequestMock.mockResolvedValueOnce(true);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
+
+    const context: object = {
+      url: nonAllowListedUrl,
+      headers: {
+        authorization: `Token ${authToken}`,
+      },
+    };
+
+    // Execute
+    await websocketAuthorization(socket, context, next);
+
+    // Validate
+    expect(authorizeRequestMock).toHaveBeenCalledTimes(1);
+    expect(authorizeRequestMock).toHaveBeenCalledWith(authToken);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith({
+      newContext: { url: nonAllowListedUrl, userUUID: authToken, ...context },
+    });
+  });
+
+  test('GIVEN unauthorized userUUID THEN next function is called with response error', async () => {
+    // Setup
+    authorizeRequestMock.mockResolvedValueOnce(false);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
+
+    const context: object = {
+      url: nonAllowListedUrl,
+      headers: {
+        authorization: `Token ${authToken}`,
+      },
+    };
+
+    const nextError: ResponseError = {
+      status: webSocketCloseCode.POLICY_VIOLATION,
+      error: new Error('Not Authorized'),
+    };
+
+    authorizeRequestMock.mockResolvedValueOnce(false);
+
+    // Execute
+    await websocketAuthorization(socket, context, next);
+
+    // Validate
+    expect(authorizeRequestMock).toHaveBeenCalledTimes(1);
+    expect(authorizeRequestMock).toHaveBeenCalledWith(authToken);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(nextError);
+  });
+
+  test('GIVEN allowlisted url without userUUID THEN authorization calls next function with userUUID added to context', async () => {
+    // Setup
+    authorizeRequestMock.mockResolvedValueOnce(true);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
+
+    const context: object = {
+      url: nonAllowListedUrl,
+      headers: {
+        authorization: `Token ${authToken}`,
+      },
+    };
+
+    const confirmRouteAuthNeeded = jest.mocked(
+      authService.confirmRouteAuthNeeded
+    );
+    confirmRouteAuthNeeded.mockReturnValueOnce(false);
+
+    // Execute
+    await websocketAuthorization(socket, context, next);
+
+    // Validate
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith({
+      newContext: { url: nonAllowListedUrl, userUUID: authToken, ...context },
+    });
+
+    expect(authorizeRequestMock).toHaveBeenCalledTimes(0);
+  });
+
+  test('GIVEN auth service called with bad input THEN next function is called with response error', async () => {
+    // Setup
+    const context: object = {
+      url: nonAllowListedUrl,
+      headers: {
+        authorization: `Token ${authToken}`,
+      },
+    };
+
+    const noUserFoundResError: ResponseError = {
+      status: 401,
+      error: Error('User not found'),
+    };
+
+    authorizeRequestMock.mockRejectedValueOnce(noUserFoundResError);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
+
+    // Execute
+    await websocketAuthorization(socket, context, next);
+
+    // Validate
+    const expectedError: ResponseError = {
+      status: webSocketCloseCode.POLICY_VIOLATION,
+      error: Error('User not found'),
+    };
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expectedError);
+  });
+
+  test('GIVEN auth service throws internal error THEN next function is called with response error', async () => {
+    // Setup
+    const context: object = {
+      url: nonAllowListedUrl,
+      headers: {
+        authorization: `Token ${authToken}`,
+      },
+    };
+
+    const noUserFoundResError: ResponseError = {
+      status: 500,
+      error: Error('bad thing'),
+    };
+
+    authorizeRequestMock.mockRejectedValueOnce(noUserFoundResError);
+    getAuthTokenMock.mockReturnValueOnce(authToken);
+
+    // Execute
+    await websocketAuthorization(socket, context, next);
+
+    // Validate
+    const expectedError: ResponseError = {
+      status: webSocketCloseCode.INTERNAL_ERROR,
+      error: Error('bad thing'),
+    };
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expectedError);
+  });
+
+  test('GIVEN get auth token fails THEN next function is called with response error', async () => {
+    // Setup
+    const context: object = {
+      url: nonAllowListedUrl,
+      headers: {
+        authorization: `Token ${authToken}`,
+      },
+    };
+
+    getAuthTokenMock.mockImplementationOnce(() => {
+      throw new Error('User not found');
+    });
+
+    // Execute
+    await websocketAuthorization(socket, context, next);
+
+    // Validate
+    const noUserFoundResError: ResponseError = {
+      status: webSocketCloseCode.POLICY_VIOLATION,
+      error: Error('User not found'),
+    };
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(noUserFoundResError);
+  });
+});

--- a/src/middleware/auth/websocket.authorization.ts
+++ b/src/middleware/auth/websocket.authorization.ts
@@ -1,0 +1,57 @@
+import { IncomingMessage } from 'http';
+import { WebSocket } from 'ws';
+import authService from '../../auth/auth.service';
+import catchError from '../../utils/catch-error';
+import webSocketCloseCode from '../../websocket/websocket-close-codes';
+import { WebSocketNextFunction } from '../../websocket/websocket-middleware-handler';
+import { ResponseError } from '../errorHandling/error.types';
+
+function websocketAuthorization(
+  socket: WebSocket,
+  context: unknown,
+  next: WebSocketNextFunction
+) {
+  const req = context as IncomingMessage;
+
+  const [error, authToken] = catchError(() => {
+    return authService.getAuthToken(req.headers);
+  });
+
+  if (error || authToken === undefined) {
+    const responseErr: ResponseError = {
+      status: webSocketCloseCode.POLICY_VIOLATION,
+      error: error as Error,
+    };
+    next(responseErr);
+    return Promise.resolve();
+  }
+
+  if (authService.confirmRouteAuthNeeded(req.url) === false) {
+    next({ newContext: { ...req, userUUID: authToken } });
+    return Promise.resolve();
+  }
+
+  return authService
+    .authorizeRequest(authToken)
+    .then(result => {
+      if (result === false) {
+        const err: ResponseError = {
+          status: webSocketCloseCode.POLICY_VIOLATION,
+          error: Error('Not Authorized'),
+        };
+        next(err);
+        return;
+      }
+
+      next({ newContext: { ...req, userUUID: authToken } });
+    })
+    .catch(err => {
+      err.status =
+        err.status === 401
+          ? webSocketCloseCode.POLICY_VIOLATION
+          : webSocketCloseCode.INTERNAL_ERROR;
+      next(err);
+    });
+}
+
+export default websocketAuthorization;

--- a/src/middleware/errorHandling/error.types.ts
+++ b/src/middleware/errorHandling/error.types.ts
@@ -5,4 +5,8 @@ type ResponseError = {
   json?: object;
 };
 
-export { ResponseError };
+function instanceOfResponseError(obj: unknown): boolean {
+  return obj instanceof Object && 'status' in obj && 'error' in obj;
+}
+
+export { ResponseError, instanceOfResponseError };

--- a/src/routes/router.ts
+++ b/src/routes/router.ts
@@ -1,10 +1,11 @@
 import express, { Express } from 'express';
 import { createServer } from 'http';
 import {
-  chatromoWebSocketRouter,
   chatroomRouter,
+  chatroomWebSocketRouter,
 } from '../chatrooms/chatrooms.router';
-import authorization from '../middleware/auth/authorization';
+import authorization from '../middleware/auth/express.authorization';
+import websocketAuthorization from '../middleware/auth/websocket.authorization';
 import expressErrorHandler from '../middleware/errorHandling/express-error-handler';
 import userRouter from '../users/users.router';
 import createWebSocketServer from '../websocket/websocket.server';
@@ -13,7 +14,8 @@ const expressServer: Express = express();
 
 const websocketServer = createWebSocketServer(createServer(expressServer));
 
-websocketServer.useRouter('/chatroom', chatromoWebSocketRouter);
+websocketServer.on('/', websocketAuthorization);
+websocketServer.useRouter('/chatroom', chatroomWebSocketRouter);
 
 expressServer.use(express.urlencoded({ extended: true }));
 expressServer.use(express.json());

--- a/src/websocket/websocket-router.spec.ts
+++ b/src/websocket/websocket-router.spec.ts
@@ -91,14 +91,11 @@ describe('WebSocket Router', () => {
                         'connection',
                         {
                           children: new Map(),
-                          handler: {
-                            handle: expect.any(Function),
-                            push: expect.any(Function),
-                          },
+                          middleware: [handlerFunction1],
                         },
                       ],
                     ]),
-                    handler: undefined,
+                    middleware: [],
                   },
                 ],
                 [
@@ -113,25 +110,23 @@ describe('WebSocket Router', () => {
                               'message',
                               {
                                 children: new Map(),
-                                handler: {
-                                  handle: expect.any(Function),
-                                  push: expect.any(Function),
-                                },
+                                middleware: [handlerFunction2],
                               },
                             ],
                           ]),
-                          handler: undefined,
+                          middleware: [],
                         },
                       ],
                     ]),
-                    handler: undefined,
+                    middleware: [],
                   },
                 ],
               ]),
-              handler: undefined,
+              middleware: [],
             },
           ],
         ]),
+        middleware: [],
       };
       expect(router._getRootNode()).toStrictEqual(expetedRouter);
     });

--- a/src/websocket/websocket.server.spec.ts
+++ b/src/websocket/websocket.server.spec.ts
@@ -34,6 +34,16 @@ describe('WebSocket Router', () => {
   });
 
   describe('Registering Events', () => {
+    test('GIVEN websocket path WHEN registering THEN should call router on method', () => {
+      const path = givenRandomString();
+      const handler = jest.fn();
+
+      const wssServer = createWebSocketServer(httpServer, websocketServer);
+      wssServer.on(path, handler);
+
+      expect(routerMock.on).toHaveBeenCalledWith(path, undefined, handler);
+    });
+
     test('GIVEN websocket event WHEN registering THEN should call router on method', () => {
       const path = givenRandomString();
       const event = givenRandomString();

--- a/src/websocket/websocket.server.ts
+++ b/src/websocket/websocket.server.ts
@@ -42,7 +42,8 @@ function createWebSocketServer(
 
         const eventData = {
           message,
-          ...request,
+          headers: request.headers,
+          url: request.url,
         };
 
         onMessageHandlers.handle(socket, eventData);
@@ -84,6 +85,10 @@ function createWebSocketServer(
     router.on(path, event, ...handlers);
   }
 
+  function on(path: string, ...handlers: WebSocketRouterFunction[]) {
+    router.on(path, undefined, ...handlers);
+  }
+
   function useRouter(path: string, otherRouter: WebSocketRouter) {
     router.merge(path, otherRouter);
   }
@@ -92,6 +97,7 @@ function createWebSocketServer(
     onWebSocketEvent,
     onWebSocketMessage,
     onWebSocketConnection,
+    on,
     useRouter,
     httpServer,
   };

--- a/src/websocket/websocket.validator.spec.ts
+++ b/src/websocket/websocket.validator.spec.ts
@@ -1,11 +1,12 @@
 import { IncomingMessage } from 'http';
 import { WebSocket } from 'ws';
 import ajv from '../middleware/validation/ajv';
-import { givenRandomString } from '../utils/test-helpers';
+import { givenRandomString, givenValidUUID } from '../utils/test-helpers';
 import createWebSocketValidator, {
   getConnectionCloseContextData,
   getConnectionMessageContextData,
   getConnectionParamContextData,
+  getConnectionUserUUIDContextData,
 } from './websocket.validator';
 
 describe('WebSocket Validator', () => {
@@ -112,7 +113,6 @@ describe('WebSocket Validator', () => {
 
     test('GIVEN connection context THEN getConnectionCloseContextData returns params as objects', () => {
       // Setup
-
       const code = 1000;
       const reasonString = givenRandomString();
       const reason = Buffer.from(reasonString);
@@ -125,6 +125,20 @@ describe('WebSocket Validator', () => {
       expect(data).toStrictEqual({
         closeCode: code,
         closeReason: reasonString,
+      });
+    });
+
+    test('GIVEN connection context THEN getConnectionUserUUIDContextData returns userUUID in objects', () => {
+      // Setup
+      const userUUID = givenValidUUID();
+      const context = { userUUID };
+
+      // Execute
+      const data = getConnectionUserUUIDContextData(context);
+
+      // Validate
+      expect(data).toStrictEqual({
+        userUUID,
       });
     });
   });

--- a/src/websocket/websocket.validator.ts
+++ b/src/websocket/websocket.validator.ts
@@ -30,6 +30,11 @@ function getConnectionCloseContextData(context: unknown) {
   };
 }
 
+function getConnectionUserUUIDContextData(context: unknown) {
+  const { userUUID } = context as { userUUID: string };
+  return { userUUID };
+}
+
 function createWebSocketValidator(
   validateFunction: ValidateFunction,
   ...getContextDataFunctions: GetContextDataFunction[]
@@ -62,4 +67,5 @@ export {
   getConnectionCloseContextData,
   getConnectionMessageContextData,
   getConnectionParamContextData,
+  getConnectionUserUUIDContextData,
 };


### PR DESCRIPTION
Moving userUUID from being passed in body to being passed as Authentication header with auth type `token`

Example:
```
{
    authentication: "token afba93f4-abad-496e-98b4-518d8541d849"
}
```