### PR TITLE
Treating ws subprotocols as headers

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -40,7 +40,9 @@ function authService() {
       throw new Error('Not Authorized');
     }
 
-    const [authType, authToken] = authHeader.split(' ');
+    const [authType, authToken] = authHeader.split(/\s|%20/);
+
+    console.log(authType, authToken);
 
     if (authType !== 'Token') {
       throw new Error('Incorrect Authorization Type');

--- a/src/websocket/websocket.server.spec.ts
+++ b/src/websocket/websocket.server.spec.ts
@@ -95,7 +95,7 @@ describe('WebSocket Router', () => {
 
     beforeEach(() => {
       url = `/${givenRandomString()}`;
-      incomingMessageMock = { url } as IncomingMessage;
+      incomingMessageMock = { url, headers: {} } as IncomingMessage;
 
       // @ts-expect-error - null input is not included in types
       socket = new WebSocket(null, undefined, {});

--- a/src/websocket/websocket.server.ts
+++ b/src/websocket/websocket.server.ts
@@ -5,6 +5,7 @@ import { urlEndToURL } from '../utils/url-helpers';
 import { WebSocketRouterFunction } from './websocket-middleware-handler';
 import websocketRouter, { WebSocketRouter } from './websocket-router';
 import { WebSocketError } from './websocket.message-schema';
+import { subProtocolsToObject } from './websocket.utils';
 
 function createWebSocketServer(
   httpServer: Server,
@@ -22,6 +23,16 @@ function createWebSocketServer(
     'connection',
     (socket: WebSocket, request: IncomingMessage) => {
       const requestUrl = urlEndToURL(request.url);
+
+      const subProtocol =
+        request.headers['sec-websocket-protocol']?.split(', ') ?? [];
+
+      request.headers = {
+        ...request.headers,
+        ...subProtocolsToObject(subProtocol),
+      };
+
+      console.log(request.headers);
 
       const connectionHandler = router.get(requestUrl.pathname, 'connection');
       connectionHandler.handle(socket, request);

--- a/src/websocket/websocket.utils.spec.ts
+++ b/src/websocket/websocket.utils.spec.ts
@@ -1,0 +1,73 @@
+import { subProtocolsToObject } from './websocket.utils';
+
+describe('subProtocolsToObject', () => {
+  test('GIVEN an array of sub-protocols THEN convert it to an object', () => {
+    // Setup
+    const subProtocols = ['protocol1', 'value1', 'protocol2', 'value2'];
+    const expected = {
+      protocol1: 'value1',
+      protocol2: 'value2',
+    };
+
+    // Execute
+    const result = subProtocolsToObject(subProtocols);
+
+    // Validate
+    expect(result).toEqual(expected);
+  });
+
+  test('GIVEN an empty array THEN return an empty object', () => {
+    // Setup
+    const subProtocols: string[] = [];
+    const expected = {};
+
+    // Execute
+    const result = subProtocolsToObject(subProtocols);
+
+    // Validate
+    expect(result).toEqual(expected);
+  });
+
+  test('GIVEN an array with one protocol without a value THEN return an object with the protocol and undefined value', () => {
+    // Setup
+    const subProtocols = ['protocol1'];
+    const expected = {
+      protocol1: undefined,
+    };
+
+    // Execute
+    const result = subProtocolsToObject(subProtocols);
+
+    // Validate
+    expect(result).toEqual(expected);
+  });
+
+  test('GIVEN an array with an odd number of elements THEN return an object with the last protocol having undefined value', () => {
+    // Setup
+    const subProtocols = ['protocol1', 'value1', 'protocol2'];
+    const expected = {
+      protocol1: 'value1',
+      protocol2: undefined,
+    };
+
+    // Execute
+    const result = subProtocolsToObject(subProtocols);
+
+    // Validate
+    expect(result).toEqual(expected);
+  });
+
+  test('GIVEN an array with duplicate protocols THEN return an object with the last value for the duplicate protocol', () => {
+    // Setup
+    const subProtocols = ['protocol1', 'value1', 'protocol1', 'value2'];
+    const expected = {
+      protocol1: 'value2',
+    };
+
+    // Execute
+    const result = subProtocolsToObject(subProtocols);
+
+    // Validate
+    expect(result).toEqual(expected);
+  });
+});

--- a/src/websocket/websocket.utils.ts
+++ b/src/websocket/websocket.utils.ts
@@ -1,0 +1,11 @@
+function subProtocolsToObject(subProtocols: string[]): object {
+  const result: { [key: string]: string } = {};
+
+  for (let i = 0; i < subProtocols.length; i += 2) {
+    result[subProtocols[i].toLowerCase()] = subProtocols[i + 1];
+  }
+
+  return result;
+}
+
+export { subProtocolsToObject };


### PR DESCRIPTION
All incoming subprotocols from websocket messages will be converted into headers