### PR TITLE
Adding message saver to mongodb and updated message schema

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,5 +1,8 @@
 import { httpServerConfig } from './config/express.config';
+import messageSaver from './messages/message-saver';
 import httpServer from './routes/router';
+
+messageSaver();
 
 httpServer.listen(httpServerConfig.PORT, httpServerConfig.IP, () => {
   console.log(

--- a/src/chatrooms/chatrooms.controller.ts
+++ b/src/chatrooms/chatrooms.controller.ts
@@ -31,7 +31,13 @@ function chatroomController() {
 
     const onMessage = (event: EventBusEvent) => {
       const eventValue = event.value as MessageEvent;
-      socket.send(JSON.stringify(eventValue.message));
+
+      const outgoing = {
+        ...eventValue.message,
+        timeStamp: eventValue.timestamp,
+      };
+
+      socket.send(JSON.stringify(outgoing));
     };
 
     return chatroomService

--- a/src/chatrooms/chatrooms.controller.ts
+++ b/src/chatrooms/chatrooms.controller.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
-import { MessageSchema } from '../messages/messages.schema';
+import { EventBusEvent } from '../events/events.types';
+import { MessageEvent, MessageSchema } from '../messages/messages.schema';
 import { WebSocketRouterFunction } from '../websocket/websocket-middleware-handler';
 import chatroomService from './chatrooms.service';
 import { JoinChatroomSchema } from './validation/join-chatroom.schema';
@@ -28,8 +29,9 @@ function chatroomController() {
   ): Promise<void> => {
     const { chatroomUUID, userUUID } = context as JoinChatroomSchema;
 
-    const onMessage = (message: object) => {
-      socket.send(JSON.stringify(message));
+    const onMessage = (event: EventBusEvent) => {
+      const eventValue = event.value as MessageEvent;
+      socket.send(JSON.stringify(eventValue.message));
     };
 
     return chatroomService

--- a/src/chatrooms/chatrooms.service.spec.ts
+++ b/src/chatrooms/chatrooms.service.spec.ts
@@ -1,3 +1,4 @@
+import { UUID } from 'crypto';
 import { Kafka } from 'kafkajs';
 import { QueryResult } from 'pg';
 import { EventAdmin, EventLedger } from '../events/events.types';
@@ -285,6 +286,10 @@ describe('Chatroom Service', () => {
       // Setup
       eventLedger.submitEvent = jest.fn();
 
+      const randomUUIDSpy = jest.spyOn(crypto, 'randomUUID');
+      const uuid = givenValidUUID() as UUID;
+      randomUUIDSpy.mockImplementation(() => uuid);
+
       // Execute
       await chatroomService.receiveChatroomMessage(
         chatroomUUID,
@@ -295,8 +300,12 @@ describe('Chatroom Service', () => {
       // Validate
       expect(eventLedger.submitEvent).toHaveBeenCalledTimes(1);
       expect(eventLedger.submitEvent).toHaveBeenCalledWith(chatroomUUID, {
-        key: 'chat',
-        value: processedMessage,
+        key: uuid,
+        value: {
+          message: processedMessage,
+          chatroomUUID,
+          userUUID,
+        },
       });
     });
   });

--- a/src/chatrooms/chatrooms.service.spec.ts
+++ b/src/chatrooms/chatrooms.service.spec.ts
@@ -290,6 +290,9 @@ describe('Chatroom Service', () => {
       const uuid = givenValidUUID() as UUID;
       randomUUIDSpy.mockImplementation(() => uuid);
 
+      const mockDate = new Date('2020-01-01');
+      jest.useFakeTimers().setSystemTime(mockDate);
+
       // Execute
       await chatroomService.receiveChatroomMessage(
         chatroomUUID,
@@ -305,6 +308,7 @@ describe('Chatroom Service', () => {
           message: processedMessage,
           chatroomUUID,
           userUUID,
+          timestamp: mockDate.toISOString(),
         },
       });
     });

--- a/src/chatrooms/chatrooms.service.ts
+++ b/src/chatrooms/chatrooms.service.ts
@@ -72,6 +72,7 @@ function chatroomService(kafka: Kafka, ledger = createKafkaLedger(kafka)) {
         message: processedMessage,
         chatroomUUID,
         userUUID,
+        timestamp: new Date().toISOString(),
       },
     };
 

--- a/src/chatrooms/chatrooms.service.ts
+++ b/src/chatrooms/chatrooms.service.ts
@@ -1,5 +1,5 @@
 import { Kafka } from 'kafkajs';
-import { EventBusEvent } from '../events/events.types';
+import { EventBusEvent, EventConsumerHandler } from '../events/events.types';
 import kafkaEvents from '../events/kafka';
 import createKafkaAdmin from '../events/kafka/kafka.admin';
 import createKafkaLedger from '../events/kafka/kafka.ledger';
@@ -39,7 +39,7 @@ function chatroomService(kafka: Kafka, ledger = createKafkaLedger(kafka)) {
   async function joinChatroom(
     chatroomUUID: string,
     userUUID: string,
-    onMessage: (message: object) => void
+    onMessage: EventConsumerHandler
   ) {
     await createChatroomUserLinkQuery(chatroomUUID, userUUID);
 
@@ -61,14 +61,18 @@ function chatroomService(kafka: Kafka, ledger = createKafkaLedger(kafka)) {
       chatroomUUID,
       userUUID,
     };
-    const eventValue = await messagesService.processIncomingMessage(
+    const processedMessage = await messagesService.processIncomingMessage(
       message,
       messageMetadata
     );
 
     const eventBusMessage: EventBusEvent = {
-      key: message.messageType,
-      value: eventValue,
+      key: crypto.randomUUID(),
+      value: {
+        message: processedMessage,
+        chatroomUUID,
+        userUUID,
+      },
     };
 
     ledger.submitEvent(chatroomUUID, eventBusMessage);

--- a/src/db/mongodb/index.spec.ts
+++ b/src/db/mongodb/index.spec.ts
@@ -36,4 +36,28 @@ describe('MongoDB', () => {
       expect(mongoDbMock.collection).toHaveBeenCalledWith(collectionName);
     });
   });
+
+  describe('insertItem', () => {
+    test('GIVEN valid item THEN should insert the item into the collection', async () => {
+      // Setup
+      const dbName = 'testDB';
+      const collectionName = 'testCollection';
+      const item = { name: 'testItem' };
+      const insertOneMock = jest
+        .fn()
+        .mockResolvedValue({ insertedId: '12345' });
+      mongoCollectionMock.mockReturnValue({
+        insertOne: insertOneMock,
+      });
+
+      // Execute
+      const connection = await createMongoConnection(dbName, collectionName);
+      const result = await connection.saveItem(item);
+
+      // Validate
+      expect(insertOneMock).toHaveBeenCalledTimes(1);
+      expect(insertOneMock).toHaveBeenCalledWith(item);
+      expect(result).toEqual({ insertedId: '12345' });
+    });
+  });
 });

--- a/src/db/mongodb/index.ts
+++ b/src/db/mongodb/index.ts
@@ -1,14 +1,25 @@
-import { mongoClient, mongoDBName } from '../../config/mongodb.config';
+import { mongoClient } from '../../config/mongodb.config';
+
+type DocumentDBConnection = {
+  saveItem: (item: object) => Promise<unknown>;
+};
 
 async function createMongoConnection(
-  dbName: string = mongoDBName,
+  dbName: string,
   collectionName: string
-) {
+): Promise<DocumentDBConnection> {
   const mongoConnection = await mongoClient.connect();
   const db = mongoConnection.db(dbName);
-  // TODO: Remove below ling when adding functionality
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const collection = db.collection(collectionName);
+
+  function saveItem(item: object) {
+    return collection.insertOne(item);
+  }
+
+  return {
+    saveItem,
+  };
 }
 
 export default createMongoConnection;
+export type { DocumentDBConnection };

--- a/src/events/kafka/kafka.consumer.spec.ts
+++ b/src/events/kafka/kafka.consumer.spec.ts
@@ -1,7 +1,7 @@
 import { Consumer, EachMessagePayload, Kafka, KafkaMessage } from 'kafkajs';
 import {
   givenRandomInt,
-  givenRandomJson,
+  givenRandomObject,
   givenRandomString,
 } from '../../utils/test-helpers';
 import { EventConsumer } from '../events.types';
@@ -62,7 +62,7 @@ describe('Events Consumer', () => {
 
       const partition = givenRandomInt();
       const messageKey = givenRandomString();
-      const messageValue = givenRandomJson();
+      const messageValue = givenRandomObject();
       const message = {
         key: messageKey,
         value: JSON.stringify(messageValue),
@@ -151,7 +151,7 @@ describe('Events Consumer', () => {
       const kafkaConsumerRunMock = jest.mocked(kafkaConsumer.run);
 
       const partition = givenRandomInt();
-      const messageValue = givenRandomJson();
+      const messageValue = givenRandomObject();
       const message = {
         key: null,
         value: JSON.stringify(messageValue),

--- a/src/events/kafka/kafka.consumer.ts
+++ b/src/events/kafka/kafka.consumer.ts
@@ -8,7 +8,7 @@ import {
 async function createKafkaConsumer(
   kafka: Kafka,
   groupId: string,
-  topics: string[]
+  topics: (string | RegExp)[]
 ): Promise<EventConsumer> {
   const consumer = kafka.consumer({ groupId });
 

--- a/src/events/kafka/kafka.ledger.spec.ts
+++ b/src/events/kafka/kafka.ledger.spec.ts
@@ -1,5 +1,5 @@
 import { Kafka } from 'kafkajs';
-import { givenRandomJson, givenRandomString } from '../../utils/test-helpers';
+import { givenRandomObject, givenRandomString } from '../../utils/test-helpers';
 import { EventBusEvent } from '../events.types';
 import createKafkaConsumer from './kafka.consumer';
 import createKafkaLedger from './kafka.ledger';
@@ -62,7 +62,7 @@ describe('Kafka Ledger', () => {
       // Setup
       const message: EventBusEvent = {
         key: givenRandomString(),
-        value: givenRandomJson(),
+        value: givenRandomObject(),
       };
 
       // Execute
@@ -78,7 +78,7 @@ describe('Kafka Ledger', () => {
       const topic = 'non-existent-topic';
       const message: EventBusEvent = {
         key: givenRandomString(),
-        value: givenRandomJson(),
+        value: givenRandomObject(),
       };
 
       // Execute and Validate

--- a/src/events/kafka/kafka.producer.spec.ts
+++ b/src/events/kafka/kafka.producer.spec.ts
@@ -1,5 +1,5 @@
 import { Kafka, Producer } from 'kafkajs';
-import { givenRandomJson, givenRandomString } from '../../utils/test-helpers';
+import { givenRandomObject, givenRandomString } from '../../utils/test-helpers';
 import { EventBusEvent, EventProducer } from '../events.types';
 import createKafkaProducer from './kakfa.producer';
 
@@ -48,7 +48,7 @@ describe('Events Producer', () => {
 
       const producerEvent: EventBusEvent = {
         key: givenRandomString(),
-        value: givenRandomJson(),
+        value: givenRandomObject(),
       };
 
       // Execute

--- a/src/messages/message-saver.spec.ts
+++ b/src/messages/message-saver.spec.ts
@@ -1,0 +1,99 @@
+import { Kafka } from 'kafkajs';
+import createMongoDBConnection, { DocumentDBConnection } from '../db/mongodb';
+import { EventConsumer } from '../events/events.types';
+import kafkaEvents from '../events/kafka';
+import createKafkaConsumer from '../events/kafka/kafka.consumer';
+import { givenRandomObject, givenValidUUID } from '../utils/test-helpers';
+import messageSaver from './message-saver';
+
+jest.mock('mongodb');
+jest.mock('../events/kafka', () => {
+  return {
+    getKafka: jest.fn(),
+  };
+});
+jest.mock('../events/kafka/kafka.consumer');
+jest.mock('../db/mongodb');
+
+describe('Message Saver', () => {
+  beforeAll(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  test('GIVEN messageSaver is create THEN all values are configured correctly', async () => {
+    // Setup
+    const kakfaInstanceMock = {} as Kafka;
+    const getKafkaMock = kafkaEvents.getKafka as jest.Mock;
+    getKafkaMock.mockReturnValue(kakfaInstanceMock);
+
+    const kafkaComsumerMock = {} as EventConsumer;
+    kafkaComsumerMock.setEventHandler = jest.fn();
+    const createKafkaConsumerMock = jest.mocked(createKafkaConsumer);
+    createKafkaConsumerMock.mockResolvedValue(kafkaComsumerMock);
+
+    const mongoDBConnectionMock = {} as DocumentDBConnection;
+    mongoDBConnectionMock.saveItem = jest.fn();
+    const createMongoDBConnectionMock = jest.mocked(createMongoDBConnection);
+    createMongoDBConnectionMock.mockResolvedValue(mongoDBConnectionMock);
+
+    // Execute
+    await messageSaver();
+
+    // Validate
+    expect(getKafkaMock).toHaveBeenCalledTimes(1);
+
+    expect(createKafkaConsumerMock).toHaveBeenCalledTimes(1);
+    expect(createKafkaConsumerMock).toHaveBeenCalledWith(
+      kakfaInstanceMock,
+      'message-connector-group',
+      [/^[^_+].*/]
+    );
+
+    expect(createMongoDBConnectionMock).toHaveBeenCalledTimes(1);
+    expect(createMongoDBConnectionMock).toHaveBeenCalledWith(
+      'emojive_document_db',
+      'messages'
+    );
+  });
+
+  describe('Event Handler', () => {
+    const kakfaInstanceMock = {} as Kafka;
+    const kafkaComsumerMock = {} as EventConsumer;
+    const mongoDBConnectionMock = {} as DocumentDBConnection;
+
+    beforeAll(async () => {
+      // Setup
+      const getKafkaMock = kafkaEvents.getKafka as jest.Mock;
+      getKafkaMock.mockReturnValue(kakfaInstanceMock);
+
+      kafkaComsumerMock.setEventHandler = jest.fn();
+      const createKafkaConsumerMock = jest.mocked(createKafkaConsumer);
+      createKafkaConsumerMock.mockResolvedValue(kafkaComsumerMock);
+
+      mongoDBConnectionMock.saveItem = jest.fn();
+      const createMongoDBConnectionMock = jest.mocked(createMongoDBConnection);
+      createMongoDBConnectionMock.mockResolvedValue(mongoDBConnectionMock);
+    });
+
+    test("GIVEN messageSaver received kafka event THEN it's saved in MongoDB", async () => {
+      // Setup
+      await messageSaver();
+      const messageHandler = (kafkaComsumerMock.setEventHandler as jest.Mock)
+        .mock.calls[0][0];
+
+      // Execute
+      const message = {
+        key: givenValidUUID(),
+        value: givenRandomObject(),
+      };
+      messageHandler(message);
+
+      // Validate
+      expect(mongoDBConnectionMock.saveItem).toHaveBeenCalledTimes(1);
+      expect(mongoDBConnectionMock.saveItem).toHaveBeenCalledWith({
+        _id: message.key,
+        value: message.value,
+      });
+    });
+  });
+});

--- a/src/messages/message-saver.ts
+++ b/src/messages/message-saver.ts
@@ -1,0 +1,35 @@
+import {
+  mongoDBMessageCollection,
+  mongoDBName,
+} from '../config/mongodb.config';
+import createMongoDBConnection from '../db/mongodb';
+import kafkaEvents from '../events/kafka';
+import createKafkaConsumer from '../events/kafka/kafka.consumer';
+
+async function messageSaver() {
+  console.log('Starting Message Saver');
+
+  const MESSAGE_CONNECTOR_GOURP_ID = 'message-connector-group';
+  const ALL_TOPIC_REGEX = /^[^_+].*/;
+
+  const kafkaInstance = kafkaEvents.getKafka();
+  const consumer = await createKafkaConsumer(
+    kafkaInstance,
+    MESSAGE_CONNECTOR_GOURP_ID,
+    [ALL_TOPIC_REGEX]
+  );
+
+  const mongoDB = await createMongoDBConnection(
+    mongoDBName,
+    mongoDBMessageCollection
+  );
+
+  consumer.setEventHandler(message => {
+    mongoDB.saveItem({
+      _id: message.key,
+      value: message.value,
+    });
+  });
+}
+
+export default messageSaver;

--- a/src/messages/messages.schema.ts
+++ b/src/messages/messages.schema.ts
@@ -2,6 +2,7 @@ type MessageEvent = {
   message: object;
   chatroomUUID: string;
   userUUID: string;
+  timestamp: string;
 };
 
 type MessageSchema = {

--- a/src/messages/messages.schema.ts
+++ b/src/messages/messages.schema.ts
@@ -1,3 +1,9 @@
+type MessageEvent = {
+  message: object;
+  chatroomUUID: string;
+  userUUID: string;
+};
+
 type MessageSchema = {
   messageType: 'chat' | 'join' | 'leave';
 };
@@ -11,4 +17,4 @@ type ChatMessageData = {
   sender: string;
 };
 
-export type { ChatMessageData, ChatMessageSchema, MessageSchema };
+export type { ChatMessageData, ChatMessageSchema, MessageEvent, MessageSchema };

--- a/src/messages/messages.service.spec.ts
+++ b/src/messages/messages.service.spec.ts
@@ -33,6 +33,7 @@ describe('MessageService', () => {
     expect(result).toEqual({
       messageText: messageText,
       sender: userData.user_name,
+      messageType: 'chat',
     });
   });
 
@@ -51,7 +52,9 @@ describe('MessageService', () => {
       'Message with unknown type: ',
       message
     );
-    expect(result).toEqual({});
+    expect(result).toEqual({
+      messageType: 'unknown',
+    });
   });
 
   test('GIVEN a chat message without userUUID WHEN processed THEN it should throw an error', async () => {

--- a/src/messages/messages.service.ts
+++ b/src/messages/messages.service.ts
@@ -25,7 +25,11 @@ function messageService(): MessageService {
       processorLookup[message.messageType as keyof typeof processorLookup] ??
       _defaultMessageProcessor;
 
-    return await processor(message, messageData);
+    const formattedMessage = await processor(message, messageData);
+    return {
+      ...formattedMessage,
+      messageType: message.messageType,
+    };
   }
 
   function _defaultMessageProcessor(message: MessageSchema): object {

--- a/src/utils/test-helpers.ts
+++ b/src/utils/test-helpers.ts
@@ -2,8 +2,8 @@ import { random as randomEmoji } from 'node-emoji';
 import { LanguageTag } from '../languages/languages.types';
 import { ResponseError } from '../middleware/errorHandling/error.types';
 
-export function givenRandomString(length: number = 10) {
-  const characters = 'abcdefghijklmnopqrstuvwxyz1234567890';
+export function givenRandomString(length: number = 10, characterSet?: string) {
+  const characters = characterSet ?? 'abcdefghijklmnopqrstuvwxyz1234567890';
   let result = '';
   const charactersLength = characters.length;
   for (let i = 0; i < length; i++) {
@@ -13,7 +13,13 @@ export function givenRandomString(length: number = 10) {
 }
 
 export function givenValidUUID(): string {
-  return 'a1aa4073-d4d2-4135-b4d8-a24bf3e7dca6';
+  const hexCharacters = 'abcdef1234567890';
+  const part1 = givenRandomString(8, hexCharacters);
+  const part2 = givenRandomString(4, hexCharacters);
+  const part3 = givenRandomString(4, hexCharacters);
+  const part4 = givenRandomString(4, hexCharacters);
+  const part5 = givenRandomString(12, hexCharacters);
+  return `${part1}-${part2}-${part3}-${part4}-${part5}`;
 }
 
 export function givenInvalidUUID(): string {
@@ -37,7 +43,7 @@ export function givenRandomError() {
 
 export function givenRandomResponseError(
   statusCode: number = 500,
-  json: object = givenRandomJson(),
+  json: object = givenRandomObject(),
   externalMessage: string = givenRandomString()
 ) {
   const error = new Error(givenRandomString());
@@ -93,8 +99,10 @@ export function givenLanguageTag(
   };
 }
 
-export function givenRandomJson(additionalJson?: object) {
+export function givenRandomObject(additionalJson?: object) {
   return {
+    [givenRandomString()]: givenRandomString(),
+    [givenRandomString()]: givenRandomString(),
     [givenRandomString()]: givenRandomString(),
     ...additionalJson,
   };

--- a/src/websocket/websocket.server.spec.ts
+++ b/src/websocket/websocket.server.spec.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, Server } from 'http';
 import { MessageEvent, WebSocket, WebSocketServer } from 'ws';
-import { givenRandomJson, givenRandomString } from '../utils/test-helpers';
+import { givenRandomObject, givenRandomString } from '../utils/test-helpers';
 import {
   WebSocketRouter,
   default as websocketRouter,
@@ -130,7 +130,7 @@ describe('WebSocket Router', () => {
       test('GIVEN websocket message WHEN handling THEN should call router get method and event handler', () => {
         // Setup
         const messageEvent = {} as MessageEvent;
-        const eventJson = givenRandomJson();
+        const eventJson = givenRandomObject();
         messageEvent.toString = () => JSON.stringify(eventJson);
 
         const wssServer = createWebSocketServer(httpServer, websocketServer);


### PR DESCRIPTION
# Message Saver
- Adding connector from kafka event stream to mongodb to save all messages transmitted

# Message Schema
- Updated messages schema to now have more meta data such as chatroomUUID, userUUID, and timestamp
- Schema now has a message field which is used to determine what data is sent to the user

# Kafka Events
- Kafka requires all events to have a unique key (if specified). To fulfill this, I am generated a UUID for the messages