### PR TITLE
Fixing issue where chatroom-user links not deleted on leave

### DIFF
--- a/src/chatrooms/chatrooms.router.ts
+++ b/src/chatrooms/chatrooms.router.ts
@@ -33,4 +33,10 @@ chatroomWebSocketRouter.onWebSocketClose(
   chatroomController.leaveChatroom
 );
 
+chatroomWebSocketRouter.onWebSocketError(
+  '/',
+  leaveChatroomValidator,
+  chatroomController.leaveChatroom
+);
+
 export { chatroomRouter, chatroomWebSocketRouter };

--- a/src/chatrooms/chatrooms.service.spec.ts
+++ b/src/chatrooms/chatrooms.service.spec.ts
@@ -211,10 +211,15 @@ describe('Chatroom Service', () => {
 
     test('Given valid chatroom and user UUIDs THEN user is removed from chatroom', async () => {
       // Setup
+
+      const deleteChatroomUserLinkQueryResult = {} as QueryResult;
+
       const deleteChatroomUserLinkQueryMock = jest.mocked(
         deleteChatroomUserLinkQuery
       );
-      deleteChatroomUserLinkQueryMock.mockResolvedValueOnce();
+      deleteChatroomUserLinkQueryMock.mockResolvedValueOnce(
+        deleteChatroomUserLinkQueryResult
+      );
 
       // Execute
       await chatroomService.leaveChatroom(chatroomUUID, userUUID);

--- a/src/chatrooms/db/chatrooms.queries.ts
+++ b/src/chatrooms/db/chatrooms.queries.ts
@@ -37,15 +37,12 @@ async function createChatroomUserLinkQuery(
   }
 }
 
-async function deleteChatroomUserLinkQuery(
-  chatroomUUID: string,
-  userUUID: string
-) {
+function deleteChatroomUserLinkQuery(chatroomUUID: string, userUUID: string) {
   const queryText =
     'DELETE FROM chatrooms_users WHERE chatroom_id IN (SELECT chatroom_id FROM chatrooms WHERE chatroom_uuid = $1) AND user_id IN (SELECT user_id FROM users WHERE user_uuid = $2)';
   const values = [chatroomUUID, userUUID];
 
-  await query(queryText, values);
+  return query(queryText, values);
 }
 
 export {

--- a/src/chatrooms/validation/leave-chatroom.schema.ts
+++ b/src/chatrooms/validation/leave-chatroom.schema.ts
@@ -2,7 +2,6 @@ import { JSONSchemaType } from 'ajv';
 import ajv from '../../middleware/validation/ajv';
 import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
-  getConnectionCloseContextData,
   getConnectionParamContextData,
   getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
@@ -10,8 +9,6 @@ import createWebSocketValidator, {
 type LeaveChatroomSchema = {
   chatroomUUID: string;
   userUUID: string;
-  closeCode: number;
-  closeReason: string;
 };
 
 const leaveChatroomSchema: JSONSchemaType<LeaveChatroomSchema> = {
@@ -35,23 +32,9 @@ const leaveChatroomSchema: JSONSchemaType<LeaveChatroomSchema> = {
         format: `${VALIDATION_ERRORS.FORMAT} UUID`,
       },
     },
-    closeCode: {
-      type: 'number',
-      nullable: false,
-      errorMessage: {
-        type: `${VALIDATION_ERRORS.TYPE} Number`,
-      },
-    },
-    closeReason: {
-      type: 'string',
-      nullable: false,
-      errorMessage: {
-        type: `${VALIDATION_ERRORS.TYPE} String`,
-      },
-    },
   },
 
-  required: ['chatroomUUID', 'userUUID', 'closeCode', 'closeReason'],
+  required: ['chatroomUUID', 'userUUID'],
   additionalProperties: true,
 };
 
@@ -60,8 +43,7 @@ const validateCreateChatroom = ajv.compile(leaveChatroomSchema);
 const leaveChatroomValidator = createWebSocketValidator(
   validateCreateChatroom,
   getConnectionUserUUIDContextData,
-  getConnectionParamContextData,
-  getConnectionCloseContextData
+  getConnectionParamContextData
 );
 
 export { leaveChatroomValidator };

--- a/src/websocket/websocket-error-handler.ts
+++ b/src/websocket/websocket-error-handler.ts
@@ -18,11 +18,17 @@ async function websocketErrorHandler(
     error: formattedError.externalMessage,
     ...formattedError.json,
   });
-  socket.send(errorResponse);
-  socket.close(
-    formattedError.status,
-    'See previous websocket message for details'
-  );
+
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.send(errorResponse);
+    socket.close(
+      formattedError.status,
+      'See previous websocket message for details'
+    );
+  } else {
+    console.error(`Socket is unable to receive error: ${errorResponse}`);
+  }
+
   return formattedError;
 }
 

--- a/src/websocket/websocket-router.spec.ts
+++ b/src/websocket/websocket-router.spec.ts
@@ -39,20 +39,21 @@ describe('WebSocket Router', () => {
     expect(returnedHandler).toBe(handler);
   });
 
-  test('GIVEN a path, event not in lookup THEN empty handler is returned', () => {
+  test('GIVEN a path, event not in lookup THEN error is thrown', () => {
     // Setup
     const path = givenRandomString();
     const event = givenRandomString();
 
     const router = websocketRouter();
 
-    // Get handler
-    const returnedHandler = router.get(path, event);
-
-    // Validate
-    expect(websocketMiddlewareHandler).toHaveBeenCalledTimes(1);
-
-    expect(returnedHandler).toBe(handler);
+    // Execute & Validate
+    try {
+      router.get(path, event);
+    } catch (error) {
+      expect((error as Error).message).toBe(
+        `No middleware found for path: ${path}`
+      );
+    }
   });
 
   describe('Router Merge', () => {
@@ -167,6 +168,25 @@ describe('WebSocket Router', () => {
 
     // Get handler
     const returnedHandler = router.get(path, 'close');
+
+    // Validate
+    expect(websocketMiddlewareHandler).toHaveBeenCalledTimes(1);
+
+    expect(returnedHandler).toBe(handler);
+  });
+
+  test('GIVEN a path and handler for WebSocket error event THEN handler is added to router', () => {
+    // Setup
+    const path = givenRandomString();
+    const handlerFunction = jest.fn();
+
+    const router = websocketRouter();
+
+    // Add handler
+    router.onWebSocketError(path, handlerFunction);
+
+    // Get handler
+    const returnedHandler = router.get(path, 'error');
 
     // Validate
     expect(websocketMiddlewareHandler).toHaveBeenCalledTimes(1);

--- a/src/websocket/websocket-router.ts
+++ b/src/websocket/websocket-router.ts
@@ -26,6 +26,10 @@ interface WebSocketRouter {
     path: string,
     ...handlers: WebSocketRouterFunction[]
   ) => void;
+  onWebSocketError: (
+    path: string,
+    ...handlers: WebSocketRouterFunction[]
+  ) => void;
   merge: (path: string, otherRouter: WebSocketRouter) => void;
   get: (path: string, event: string) => WebSocketRouterHandler;
   _getRootNode: () => WebSocketRouterNode;
@@ -54,6 +58,10 @@ function websocketRouter(): WebSocketRouter {
       if (curNode === undefined || curNode == null) {
         break;
       }
+    }
+
+    if (middleware.length === 0) {
+      throw new Error('No middleware found for path: ' + path);
     }
 
     return websocketMiddlewareHandler(...middleware);
@@ -88,6 +96,13 @@ function websocketRouter(): WebSocketRouter {
     ...handlers: WebSocketRouterFunction[]
   ) {
     on(path, 'close', ...handlers);
+  }
+
+  function onWebSocketError(
+    path: string,
+    ...handlers: WebSocketRouterFunction[]
+  ) {
+    on(path, 'error', ...handlers);
   }
 
   function merge(path: string, otherRouter: WebSocketRouter) {
@@ -133,6 +148,7 @@ function websocketRouter(): WebSocketRouter {
     onWebSocketMessage,
     onWebSocketConnection,
     onWebSocketClose,
+    onWebSocketError,
     get,
     _getRootNode,
     merge,

--- a/src/websocket/websocket.server.spec.ts
+++ b/src/websocket/websocket.server.spec.ts
@@ -211,5 +211,29 @@ describe('WebSocket Router', () => {
 
       expect(wssServer.httpServer).toBe(httpServer);
     });
+
+    test('GIVEN websocket error event WHEN handling THEN should call router get method and event handler', () => {
+      // Setup
+      const error = new Error(givenRandomString());
+
+      const wssServer = createWebSocketServer(httpServer, websocketServer);
+
+      // Execute
+      websocketServer.emit('connection', socket, incomingMessageMock);
+      socket.emit('error', error);
+
+      // Validate
+      expect(routerMock.get).toHaveBeenCalledTimes(2);
+      expect(routerMock.get).toHaveBeenNthCalledWith(1, url, 'connection');
+      expect(routerMock.get).toHaveBeenNthCalledWith(2, url, 'error');
+
+      expect(eventHandler.handle).toHaveBeenCalledTimes(2);
+      expect(eventHandler.handle).toHaveBeenCalledWith(socket, {
+        error,
+        ...incomingMessageMock,
+      });
+
+      expect(wssServer.httpServer).toBe(httpServer);
+    });
   });
 });

--- a/src/websocket/websocket.server.ts
+++ b/src/websocket/websocket.server.ts
@@ -64,10 +64,23 @@ function createWebSocketServer(
         const eventData = {
           code,
           reason,
-          ...request,
+          headers: request.headers,
+          url: request.url,
         };
 
         onCloseHandlers.handle(socket, eventData);
+      });
+
+      socket.addListener('error', (error: Error) => {
+        const onErrorHandlers = router.get(requestUrl.pathname, 'error');
+
+        const eventData = {
+          error,
+          headers: request.headers,
+          url: request.url,
+        };
+
+        onErrorHandlers.handle(socket, eventData);
       });
     }
   );


### PR DESCRIPTION
# Leave Chatroom Bug Fix
## Bug
when leaving the chatroom, chatroomUUID wasn't being supplied, causing AJV to fail. Since the socket had been closed, not error was sent to the users, so it silently failed.

## Solution
- Made sure headers and url are properly being passed on close event
- Added support for on error event so that this can be handled as user leaving the chatroom
- On an open state, the error is sent to the client. otherwise, the error is logged 

# Other
- Removing close code and reason from being needed to leave chatroom since it doesn't matter
- `deleteChatroomUserLinkQuery` now returns the query instead of just waiting
- If a websocker router has no middleware an error is thrown since this shouldn't ever be the case