### PR TITLE
Changing join chatroom flow

### DIFF
--- a/src/chatrooms/chatrooms.controller.ts
+++ b/src/chatrooms/chatrooms.controller.ts
@@ -1,4 +1,6 @@
 import { RequestHandler } from 'express';
+import authService from '../auth/auth.service';
+import { catchAsyncError } from '../errorHandling/catch-error';
 import { EventBusEvent } from '../events/events.types';
 import { MessageEvent, MessageSchema } from '../messages/messages.schema';
 import { WebSocketRouterFunction } from '../websocket/websocket-middleware-handler';
@@ -22,12 +24,61 @@ function chatroomController() {
       .catch(next);
   };
 
-  const joinChatroom: WebSocketRouterFunction = (
+  const joinChatroom: RequestHandler = (
+    request,
+    response,
+    next
+  ): Promise<void> => {
+    const userUUID = authService.getAuthToken(request.headers);
+    const { chatroomUUID } = request.body;
+
+    return chatroomService
+      .joinChatroom(chatroomUUID, userUUID)
+      .then(() => {
+        response.status(201).send();
+      })
+      .catch(next);
+  };
+
+  const addUserChatroomsToContext: WebSocketRouterFunction = async (
     socket,
     context,
     next
   ): Promise<void> => {
-    const { chatroomUUID, userUUID } = context as JoinChatroomSchema;
+    const { userUUID } = context as JoinChatroomSchema;
+
+    const [error, chatrooms] = await catchAsyncError(() =>
+      chatroomService.getUserChatrooms(userUUID)
+    );
+
+    if (error) {
+      next(error);
+      return;
+    }
+
+    if (chatrooms.length === 0) {
+      next({ error: new Error('User is not part of any chatrooms') });
+      return;
+    }
+
+    if (chatrooms.length > 1) {
+      next({
+        error: new Error(`User is part of multiple chatrooms: ${chatrooms}`),
+      });
+      return;
+    }
+
+    const newContext = { ...(context as object), chatroomUUID: chatrooms[0] };
+
+    next({ newContext });
+  };
+
+  const registerUserMessageHandler: WebSocketRouterFunction = async (
+    socket,
+    context,
+    next
+  ): Promise<void> => {
+    const { userUUID, chatroomUUID } = context as JoinChatroomSchema;
 
     const onMessage = (event: EventBusEvent) => {
       const eventValue = event.value as MessageEvent;
@@ -41,7 +92,7 @@ function chatroomController() {
     };
 
     return chatroomService
-      .joinChatroom(chatroomUUID, userUUID, onMessage)
+      .addChatroomMessageReceiver(userUUID, chatroomUUID, onMessage)
       .catch(next);
   };
 
@@ -64,12 +115,16 @@ function chatroomController() {
   const leaveChatroom: WebSocketRouterFunction = (socket, context, next) => {
     const { chatroomUUID, userUUID } = context as LeaveChatroomSchema;
 
+    console.log('leaving chatroom: ', chatroomUUID, userUUID);
+
     chatroomService.leaveChatroom(chatroomUUID, userUUID).catch(next);
   };
 
   return {
     createChatroom,
     joinChatroom,
+    addUserChatroomsToContext,
+    registerUserMessageHandler,
     receiveChatroomMessage,
     leaveChatroom,
   };

--- a/src/chatrooms/chatrooms.router.ts
+++ b/src/chatrooms/chatrooms.router.ts
@@ -15,26 +15,36 @@ chatroomRouter.post(
   chatroomController.createChatroom
 );
 
+chatroomRouter.post(
+  '/join',
+  // joinCharoomValidator,
+  chatroomController.joinChatroom
+);
+
 chatroomWebSocketRouter.onWebSocketConnection(
   '/',
+  chatroomController.addUserChatroomsToContext,
   joinCharoomValidator,
-  chatroomController.joinChatroom
+  chatroomController.registerUserMessageHandler
 );
 
 chatroomWebSocketRouter.onWebSocketMessage(
   '/',
+  chatroomController.addUserChatroomsToContext,
   receiveChatroomMessageValidator,
   chatroomController.receiveChatroomMessage
 );
 
 chatroomWebSocketRouter.onWebSocketClose(
   '/',
+  chatroomController.addUserChatroomsToContext,
   leaveChatroomValidator,
   chatroomController.leaveChatroom
 );
 
 chatroomWebSocketRouter.onWebSocketError(
   '/',
+  chatroomController.addUserChatroomsToContext,
   leaveChatroomValidator,
   chatroomController.leaveChatroom
 );

--- a/src/chatrooms/db/chatrooms.queries.spec.ts
+++ b/src/chatrooms/db/chatrooms.queries.spec.ts
@@ -10,6 +10,7 @@ import {
   createChatroomQuery,
   createChatroomUserLinkQuery,
   deleteChatroomUserLinkQuery,
+  getUsersChatroomsQuery,
 } from './chatrooms.queries';
 
 jest.mock('../../db/postgres');
@@ -143,6 +144,35 @@ describe('Chatroom Queries', () => {
       await expect(
         deleteChatroomUserLinkQuery(chatroomUUID, userUUID)
       ).rejects.toThrow('Some error');
+    });
+  });
+
+  describe('Get Users Chatrooms Query', () => {
+    test('GIVEN valid input THEN query is called with proper input', async () => {
+      // Setup
+      const queryMock = jest.mocked(query);
+
+      // Execute
+      await getUsersChatroomsQuery(userUUID);
+
+      // Validate
+      expect(queryMock).toHaveBeenCalledTimes(1);
+      expect(queryMock).toHaveBeenCalledWith(
+        'SELECT chatrooms.chatroom_uuid FROM chatrooms JOIN chatrooms_users ON chatrooms.chatroom_id = chatrooms_users.chatroom_id JOIN users ON users.user_id = chatrooms_users.user_id WHERE users.user_uuid = $1',
+        [userUUID]
+      );
+    });
+
+    test('GIVEN query throws an error THEN error is thrown', async () => {
+      // Setup
+      const queryMock = jest.mocked(query);
+      const error = new Error('Some error');
+      queryMock.mockRejectedValueOnce(error);
+
+      // Execute & Validate
+      await expect(getUsersChatroomsQuery(userUUID)).rejects.toThrow(
+        'Some error'
+      );
     });
   });
 });

--- a/src/chatrooms/db/chatrooms.queries.ts
+++ b/src/chatrooms/db/chatrooms.queries.ts
@@ -45,8 +45,18 @@ function deleteChatroomUserLinkQuery(chatroomUUID: string, userUUID: string) {
   return query(queryText, values);
 }
 
+function getUsersChatroomsQuery(userUUId: string) {
+  const queryText =
+    'SELECT chatrooms.chatroom_uuid FROM chatrooms JOIN chatrooms_users ON chatrooms.chatroom_id = chatrooms_users.chatroom_id JOIN users ON users.user_id = chatrooms_users.user_id WHERE users.user_uuid = $1';
+
+  const values = [userUUId];
+
+  return query(queryText, values);
+}
+
 export {
   createChatroomQuery,
   createChatroomUserLinkQuery,
   deleteChatroomUserLinkQuery,
+  getUsersChatroomsQuery,
 };

--- a/src/chatrooms/validation/join-chatroom.schema.ts
+++ b/src/chatrooms/validation/join-chatroom.schema.ts
@@ -2,7 +2,7 @@ import { JSONSchemaType } from 'ajv';
 import ajv from '../../middleware/validation/ajv';
 import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
-  getConnectionParamContextData,
+  getConnectionChatroomUUIDContextData,
   getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
 
@@ -42,7 +42,7 @@ const validateCreateChatroom = ajv.compile(joinChatroomSchema);
 const joinCharoomValidator = createWebSocketValidator(
   validateCreateChatroom,
   getConnectionUserUUIDContextData,
-  getConnectionParamContextData
+  getConnectionChatroomUUIDContextData
 );
 
 export { joinCharoomValidator };

--- a/src/chatrooms/validation/leave-chatroom.schema.ts
+++ b/src/chatrooms/validation/leave-chatroom.schema.ts
@@ -2,7 +2,7 @@ import { JSONSchemaType } from 'ajv';
 import ajv from '../../middleware/validation/ajv';
 import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
-  getConnectionParamContextData,
+  getConnectionChatroomUUIDContextData,
   getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
 
@@ -43,7 +43,7 @@ const validateCreateChatroom = ajv.compile(leaveChatroomSchema);
 const leaveChatroomValidator = createWebSocketValidator(
   validateCreateChatroom,
   getConnectionUserUUIDContextData,
-  getConnectionParamContextData
+  getConnectionChatroomUUIDContextData
 );
 
 export { leaveChatroomValidator };

--- a/src/chatrooms/validation/receive-chatroom-message.schema.ts
+++ b/src/chatrooms/validation/receive-chatroom-message.schema.ts
@@ -3,8 +3,8 @@ import { MessageSchema } from '../../messages/messages.schema';
 import ajv from '../../middleware/validation/ajv';
 import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
 import createWebSocketValidator, {
+  getConnectionChatroomUUIDContextData,
   getConnectionMessageContextData,
-  getConnectionParamContextData,
   getConnectionUserUUIDContextData,
 } from '../../websocket/websocket.validator';
 
@@ -92,7 +92,7 @@ const validateReceiveChatroomMessage = ajv.compile(
 const receiveChatroomMessageValidator = createWebSocketValidator(
   validateReceiveChatroomMessage,
   getConnectionUserUUIDContextData,
-  getConnectionParamContextData,
+  getConnectionChatroomUUIDContextData,
   getConnectionMessageContextData
 );
 

--- a/src/errorHandling/catch-error.spec.ts
+++ b/src/errorHandling/catch-error.spec.ts
@@ -1,41 +1,85 @@
-import catchError from './catch-error';
+import { catchAsyncError, catchError } from './catch-error';
 
 describe('catchError', () => {
-  test('GIVEN no error is thrown THEN should return the result of the function', () => {
-    const fn = () => 'success';
-    const result = catchError(fn);
-    expect(result).toEqual([null, 'success']);
-  });
+  describe('synchronous errors', () => {
+    test('GIVEN no error is thrown THEN should return the result of the function', () => {
+      const fn = () => 'success';
+      const result = catchError(fn);
+      expect(result).toEqual([null, 'success']);
+    });
 
-  test('GIVEN an error is thrown THEN should return an error', () => {
-    const fn = () => {
-      throw new Error('failure');
-    };
-    const result = catchError(fn);
-    expect(result).toEqual([new Error('failure')]);
-  });
+    test('GIVEN an error is thrown THEN should return an error', () => {
+      const fn = () => {
+        throw new Error('failure');
+      };
+      const result = catchError(fn);
+      expect(result).toEqual([new Error('failure')]);
+    });
 
-  test('GIVEN a non-error object is thrown THEN should return a new error', () => {
-    const fn = () => {
-      throw 'failure';
-    };
-    const result = catchError(fn);
-    expect(result).toEqual([new Error('failure')]);
-  });
+    test('GIVEN a non-error object is thrown THEN should return a new error', () => {
+      const fn = () => {
+        throw 'failure';
+      };
+      const result = catchError(fn);
+      expect(result).toEqual([new Error('failure')]);
+    });
 
-  test('GIVEN a number is thrown THEN should return a new error', () => {
-    const fn = () => {
-      throw 123;
-    };
-    const result = catchError(fn);
-    expect(result).toEqual([new Error('123')]);
-  });
+    test('GIVEN a number is thrown THEN should return a new error', () => {
+      const fn = () => {
+        throw 123;
+      };
+      const result = catchError(fn);
+      expect(result).toEqual([new Error('123')]);
+    });
 
-  test('GIVEN null is thrown THEN should return a new error', () => {
-    const fn = () => {
-      throw null;
-    };
-    const result = catchError(fn);
-    expect(result).toEqual([new Error('null')]);
+    test('GIVEN null is thrown THEN should return a new error', () => {
+      const fn = () => {
+        throw null;
+      };
+      const result = catchError(fn);
+      expect(result).toEqual([new Error('null')]);
+    });
+  });
+});
+
+describe('catchAsyncError', () => {
+  describe('asynchronous errors', () => {
+    test('GIVEN no error is thrown THEN should return the result of the function', async () => {
+      const fn = async () => 'success';
+      const result = await catchAsyncError(fn);
+      expect(result).toEqual([null, 'success']);
+    });
+
+    test('GIVEN an error is thrown THEN should return an error', async () => {
+      const fn = async () => {
+        throw new Error('failure');
+      };
+      const result = await catchAsyncError(fn);
+      expect(result).toEqual([new Error('failure')]);
+    });
+
+    test('GIVEN a non-error object is thrown THEN should return a new error', async () => {
+      const fn = async () => {
+        throw 'failure';
+      };
+      const result = await catchAsyncError(fn);
+      expect(result).toEqual([new Error('failure')]);
+    });
+
+    test('GIVEN a number is thrown THEN should return a new error', async () => {
+      const fn = async () => {
+        throw 123;
+      };
+      const result = await catchAsyncError(fn);
+      expect(result).toEqual([new Error('123')]);
+    });
+
+    test('GIVEN null is thrown THEN should return a new error', async () => {
+      const fn = async () => {
+        throw null;
+      };
+      const result = await catchAsyncError(fn);
+      expect(result).toEqual([new Error('null')]);
+    });
   });
 });

--- a/src/errorHandling/catch-error.ts
+++ b/src/errorHandling/catch-error.ts
@@ -9,4 +9,18 @@ function catchError<T>(fn: () => T): [null, T] | [Error] {
   }
 }
 
-export default catchError;
+async function catchAsyncError<T>(
+  fn: () => Promise<T>
+): Promise<[null, T] | [Error]> {
+  try {
+    const result = await fn();
+    return [null, result];
+  } catch (e) {
+    if (e instanceof Error) {
+      return [e];
+    }
+    return [new Error(String(e).toString())];
+  }
+}
+
+export { catchAsyncError, catchError };

--- a/src/events/events.types.ts
+++ b/src/events/events.types.ts
@@ -22,6 +22,10 @@ interface EventProducer {
 
 interface EventLedger {
   addConsumer: (groupId: string, topics: string[]) => Promise<EventConsumer>;
+  registerConsumerHandler: (
+    groupId: string,
+    handler: EventConsumerHandler
+  ) => void;
   addProducer: (topic: string) => Promise<EventProducer>;
   submitEvent: (topic: string, message: EventBusEvent) => Promise<void>;
   removeConsumer: (groupId: string) => void;

--- a/src/events/kafka/kafka.ledger.spec.ts
+++ b/src/events/kafka/kafka.ledger.spec.ts
@@ -15,7 +15,7 @@ describe('Kafka Ledger', () => {
   let groupId: string;
   let topic: string;
 
-  const mockConsumer = { destroy: jest.fn() };
+  const mockConsumer = { destroy: jest.fn(), setEventHandler: jest.fn() };
   const mockProducer = { sendMessage: jest.fn(), destroy: jest.fn() };
 
   beforeEach(() => {
@@ -43,6 +43,31 @@ describe('Kafka Ledger', () => {
         topic,
       ]);
       expect(consumer).toBe(mockConsumer);
+    });
+  });
+
+  describe('Register Consumer Handler', () => {
+    test('GIVEN a groupId and handler WHEN registering a consumer handler THEN it should register the handler', async () => {
+      // Setup
+      const handler = jest.fn();
+      await kafkaLedger.addConsumer(groupId, [topic]);
+
+      // Execute
+      kafkaLedger.registerConsumerHandler(groupId, handler);
+
+      // Validate
+      expect(mockConsumer.setEventHandler).toHaveBeenCalledWith(handler);
+    });
+
+    test('GIVEN a non-existent consumer WHEN registering a consumer handler THEN it should throw an error', () => {
+      // Setup
+      const handler = jest.fn();
+      const nonExistentGroupId = 'non-existent-group';
+
+      // Execute and Validate
+      expect(() =>
+        kafkaLedger.registerConsumerHandler(nonExistentGroupId, handler)
+      ).toThrow(`Consumer for group ${nonExistentGroupId} not found`);
     });
   });
 

--- a/src/middleware/auth/express.authorization.ts
+++ b/src/middleware/auth/express.authorization.ts
@@ -1,6 +1,6 @@
 import { NextFunction, Request, Response } from 'express';
 import authService from '../../auth/auth.service';
-import catchError from '../../errorHandling/catch-error';
+import { catchError } from '../../errorHandling/catch-error';
 import { ResponseError } from '../errorHandling/error.types';
 
 function authorization(

--- a/src/middleware/auth/websocket.authorization.ts
+++ b/src/middleware/auth/websocket.authorization.ts
@@ -1,7 +1,7 @@
 import { IncomingMessage } from 'http';
 import { WebSocket } from 'ws';
 import authService from '../../auth/auth.service';
-import catchError from '../../errorHandling/catch-error';
+import { catchError } from '../../errorHandling/catch-error';
 import webSocketCloseCode from '../../websocket/websocket-close-codes';
 import { WebSocketNextFunction } from '../../websocket/websocket-middleware-handler';
 import { ResponseError } from '../errorHandling/error.types';

--- a/src/utils/emoji-helpers.spec.ts
+++ b/src/utils/emoji-helpers.spec.ts
@@ -4,7 +4,18 @@ describe('Emoji Helpers', () => {
   describe('isOnlyEmojis', () => {
     test('GIVEN only emoji text THEN return true', () => {
       // Setup
-      const text = '🔒💅🚑🏺';
+      const text = '📋🚶🅿️⛄️🔪🔦🚋💳📋';
+
+      // Execute
+      const result = isOnlyEmojis(text);
+
+      // Validate
+      expect(result).toBe(true);
+    });
+
+    test('GIVEN compound emoji text THEN return true', () => {
+      // Setup
+      const text = '🍄‍🟫';
 
       // Execute
       const result = isOnlyEmojis(text);

--- a/src/utils/emoji-helpers.ts
+++ b/src/utils/emoji-helpers.ts
@@ -1,8 +1,8 @@
-import { strip as emojiStrip } from 'node-emoji';
+const NON_EMOJI_REGEX = /[^\p{Emoji}\p{Emoji_Modifier}\p{Emoji_Component}\s]/gu;
 
-function isOnlyEmojis(test: string) {
-  const strippedText = emojiStrip(test);
-  return strippedText.length === 0;
+function isOnlyEmojis(text: string) {
+  const foundNonEmoji = text.match(NON_EMOJI_REGEX);
+  return foundNonEmoji === null;
 }
 
 export { isOnlyEmojis };

--- a/src/websocket/websocket.server.ts
+++ b/src/websocket/websocket.server.ts
@@ -1,6 +1,6 @@
 import { IncomingMessage, Server } from 'http';
 import { WebSocket, WebSocketServer } from 'ws';
-import catchError from '../errorHandling/catch-error';
+import { catchError } from '../errorHandling/catch-error';
 import { urlEndToURL } from '../utils/url-helpers';
 import { WebSocketRouterFunction } from './websocket-middleware-handler';
 import websocketRouter, { WebSocketRouter } from './websocket-router';

--- a/src/websocket/websocket.validator.spec.ts
+++ b/src/websocket/websocket.validator.spec.ts
@@ -3,6 +3,7 @@ import { WebSocket } from 'ws';
 import ajv from '../middleware/validation/ajv';
 import { givenRandomString, givenValidUUID } from '../utils/test-helpers';
 import createWebSocketValidator, {
+  getConnectionChatroomUUIDContextData,
   getConnectionCloseContextData,
   getConnectionMessageContextData,
   getConnectionParamContextData,
@@ -139,6 +140,20 @@ describe('WebSocket Validator', () => {
       // Validate
       expect(data).toStrictEqual({
         userUUID,
+      });
+    });
+
+    test('GIVEN connection context THEN getConnectionChatroomUUIDContextData returns userUUID in objects', () => {
+      // Setup
+      const chatroomUUID = givenValidUUID();
+      const context = { chatroomUUID };
+
+      // Execute
+      const data = getConnectionChatroomUUIDContextData(context);
+
+      // Validate
+      expect(data).toStrictEqual({
+        chatroomUUID,
       });
     });
   });

--- a/src/websocket/websocket.validator.ts
+++ b/src/websocket/websocket.validator.ts
@@ -35,6 +35,11 @@ function getConnectionUserUUIDContextData(context: unknown) {
   return { userUUID };
 }
 
+function getConnectionChatroomUUIDContextData(context: unknown) {
+  const { chatroomUUID } = context as { chatroomUUID: string };
+  return { chatroomUUID };
+}
+
 function createWebSocketValidator(
   validateFunction: ValidateFunction,
   ...getContextDataFunctions: GetContextDataFunction[]
@@ -64,6 +69,7 @@ function createWebSocketValidator(
 
 export default createWebSocketValidator;
 export {
+  getConnectionChatroomUUIDContextData,
   getConnectionCloseContextData,
   getConnectionMessageContextData,
   getConnectionParamContextData,


### PR DESCRIPTION
OLD:
1. create user
2. create chatroom (optional)
3. establish websocket connection with chatroomUUID

NEW:
1. create user
2. create chatroom (optional)
3. join chatroom (http) - pass chatroomUUID
4. establish websocket connection

TODO:
- Decrease the number of times you need to query DB for chatroomUUID, now it is called on connection AND every message AND on leave. Would be better to have it only on connection and have the result stored in the context