### PR TITLE
Adding join and leave message when user joins and leaves chatroom

### DIFF
--- a/src/chatrooms/chatrooms.controller.spec.ts
+++ b/src/chatrooms/chatrooms.controller.spec.ts
@@ -300,7 +300,8 @@ describe('Chatroom Controller', () => {
         expect.any(Function)
       );
 
-      expect(next).toHaveBeenCalledTimes(0);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
 
     test('GIVEN error occurs while registering message handler THEN next function is called', async () => {
@@ -382,11 +383,12 @@ describe('Chatroom Controller', () => {
         })
       );
 
-      expect(next).toHaveBeenCalledTimes(0);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
   });
 
-  describe('Receive Chatroom Message', () => {
+  describe('Emit Chatroom Message', () => {
     test('GIVEN chatroom UUID, user UUID, and message THEN chatroom service is called', async () => {
       // Setup
       const socket = {} as WebSocket;
@@ -397,7 +399,7 @@ describe('Chatroom Controller', () => {
       };
 
       const receiveChatroomMessageMock = jest.mocked(
-        chatroomService.receiveChatroomMessage
+        chatroomService.emitChatroomMessage
       );
       receiveChatroomMessageMock.mockResolvedValueOnce();
 
@@ -425,7 +427,7 @@ describe('Chatroom Controller', () => {
       };
 
       const receiveChatroomMessageMock = jest.mocked(
-        chatroomService.receiveChatroomMessage
+        chatroomService.emitChatroomMessage
       );
       receiveChatroomMessageMock.mockRejectedValueOnce('Evil');
 
@@ -458,13 +460,14 @@ describe('Chatroom Controller', () => {
       leaveChatroomMock.mockResolvedValueOnce();
 
       // Execute
-      chatroomController.leaveChatroom(socket, context, next);
+      await chatroomController.leaveChatroom(socket, context, next);
 
       // Validate
       expect(leaveChatroomMock).toHaveBeenCalledTimes(1);
       expect(leaveChatroomMock).toHaveBeenCalledWith(chatroomUUID, userUUID);
 
-      expect(next).toHaveBeenCalledTimes(0);
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith();
     });
 
     test('GIVEN error occurs while leaving chatroom THEN next function is called', async () => {
@@ -485,6 +488,136 @@ describe('Chatroom Controller', () => {
       // Validate
       expect(leaveChatroomMock).toHaveBeenCalledTimes(1);
       expect(leaveChatroomMock).toHaveBeenCalledWith(chatroomUUID, userUUID);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith('Evil');
+    });
+  });
+
+  describe('Emit User Joined Chatroom Message', () => {
+    test('GIVEN user UUID and chatroom UUID THEN chatroom service is called', async () => {
+      // Setup
+      const socket = {} as WebSocket;
+      const context = {
+        userUUID,
+        chatroomUUID,
+      };
+
+      const emitChatroomMessageMock = jest.mocked(
+        chatroomService.emitChatroomMessage
+      );
+      emitChatroomMessageMock.mockResolvedValueOnce();
+
+      // Execute
+      await chatroomController.emitUserJoinedChatroomMessage(
+        socket,
+        context,
+        next
+      );
+
+      // Validate
+      expect(emitChatroomMessageMock).toHaveBeenCalledTimes(1);
+      expect(emitChatroomMessageMock).toHaveBeenCalledWith(
+        chatroomUUID,
+        userUUID,
+        { messageType: 'join' }
+      );
+
+      expect(next).toHaveBeenCalledTimes(0);
+    });
+
+    test('GIVEN error occurs while emitting join message THEN next function is called', async () => {
+      // Setup
+      const socket = {} as WebSocket;
+      const context = {
+        userUUID,
+        chatroomUUID,
+      };
+
+      const emitChatroomMessageMock = jest.mocked(
+        chatroomService.emitChatroomMessage
+      );
+      emitChatroomMessageMock.mockRejectedValueOnce('Evil');
+
+      // Execute
+      await chatroomController.emitUserJoinedChatroomMessage(
+        socket,
+        context,
+        next
+      );
+
+      // Validate
+      expect(emitChatroomMessageMock).toHaveBeenCalledTimes(1);
+      expect(emitChatroomMessageMock).toHaveBeenCalledWith(
+        chatroomUUID,
+        userUUID,
+        { messageType: 'join' }
+      );
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(next).toHaveBeenCalledWith('Evil');
+    });
+  });
+
+  describe('Emit User Left Chatroom Message', () => {
+    test('GIVEN user UUID and chatroom UUID THEN chatroom service is called', async () => {
+      // Setup
+      const socket = {} as WebSocket;
+      const context = {
+        userUUID,
+        chatroomUUID,
+      };
+
+      const emitChatroomMessageMock = jest.mocked(
+        chatroomService.emitChatroomMessage
+      );
+      emitChatroomMessageMock.mockResolvedValueOnce();
+
+      // Execute
+      await chatroomController.emitUserLeftChatroomMessage(
+        socket,
+        context,
+        next
+      );
+
+      // Validate
+      expect(emitChatroomMessageMock).toHaveBeenCalledTimes(1);
+      expect(emitChatroomMessageMock).toHaveBeenCalledWith(
+        chatroomUUID,
+        userUUID,
+        { messageType: 'leave' }
+      );
+
+      expect(next).toHaveBeenCalledTimes(0);
+    });
+
+    test('GIVEN error occurs while emitting leave message THEN next function is called', async () => {
+      // Setup
+      const socket = {} as WebSocket;
+      const context = {
+        userUUID,
+        chatroomUUID,
+      };
+
+      const emitChatroomMessageMock = jest.mocked(
+        chatroomService.emitChatroomMessage
+      );
+      emitChatroomMessageMock.mockRejectedValueOnce('Evil');
+
+      // Execute
+      await chatroomController.emitUserLeftChatroomMessage(
+        socket,
+        context,
+        next
+      );
+
+      // Validate
+      expect(emitChatroomMessageMock).toHaveBeenCalledTimes(1);
+      expect(emitChatroomMessageMock).toHaveBeenCalledWith(
+        chatroomUUID,
+        userUUID,
+        { messageType: 'leave' }
+      );
 
       expect(next).toHaveBeenCalledTimes(1);
       expect(next).toHaveBeenCalledWith('Evil');

--- a/src/chatrooms/chatrooms.router.ts
+++ b/src/chatrooms/chatrooms.router.ts
@@ -26,7 +26,8 @@ chatroomWebSocketRouter.onWebSocketConnection(
   '/',
   chatroomWebsocketValidator,
   chatroomController.addUserChatroomsToContext,
-  chatroomController.registerUserMessageHandler
+  chatroomController.registerUserMessageHandler,
+  chatroomController.emitUserJoinedChatroomMessage
 );
 
 chatroomWebSocketRouter.onWebSocketMessage(
@@ -40,14 +41,16 @@ chatroomWebSocketRouter.onWebSocketClose(
   '/',
   leaveChatroomValidator,
   chatroomController.addUserChatroomsToContext,
-  chatroomController.leaveChatroom
+  chatroomController.leaveChatroom,
+  chatroomController.emitUserLeftChatroomMessage
 );
 
 chatroomWebSocketRouter.onWebSocketError(
   '/',
   leaveChatroomValidator,
   chatroomController.addUserChatroomsToContext,
-  chatroomController.leaveChatroom
+  chatroomController.leaveChatroom,
+  chatroomController.emitUserLeftChatroomMessage
 );
 
 export { chatroomRouter, chatroomWebSocketRouter };

--- a/src/chatrooms/chatrooms.service.spec.ts
+++ b/src/chatrooms/chatrooms.service.spec.ts
@@ -284,7 +284,7 @@ describe('Chatroom Service', () => {
       jest.useFakeTimers().setSystemTime(mockDate);
 
       // Execute
-      await chatroomService.receiveChatroomMessage(
+      await chatroomService.emitChatroomMessage(
         chatroomUUID,
         userUUID,
         message

--- a/src/chatrooms/chatrooms.service.ts
+++ b/src/chatrooms/chatrooms.service.ts
@@ -58,7 +58,7 @@ function chatroomService(kafka: Kafka, ledger = createKafkaLedger(kafka)) {
     ledger.registerConsumerHandler(userUUID, handler);
   }
 
-  async function receiveChatroomMessage(
+  async function emitChatroomMessage(
     chatroomUUID: string,
     userUUID: string,
     message: MessageSchema
@@ -101,7 +101,7 @@ function chatroomService(kafka: Kafka, ledger = createKafkaLedger(kafka)) {
     addChatroomMessageReceiver,
     getUserChatrooms,
     leaveChatroom,
-    receiveChatroomMessage,
+    emitChatroomMessage,
   };
 }
 


### PR DESCRIPTION
# Join and Leave Messages
- Emojive will now emit a message saying a playing has joined or left a chatroom.
- The join and leave are emitted when the websocket message is established or disconnected (not when the user calls the joinChatroom api). This is done to make it clear that the user is in the room and is able to see messages, not just that they are member of the chatroom.