### PR TITLE
Stopping error from being thrown when last user leaves chatroom

### DIFF
--- a/src/chatrooms/chatrooms.service.spec.ts
+++ b/src/chatrooms/chatrooms.service.spec.ts
@@ -306,6 +306,31 @@ describe('Chatroom Service', () => {
         },
       });
     });
+
+    test('GIVEN ledger submit event fails THEN error is thrown', async () => {
+      // Setup
+      eventLedger.submitEvent = jest.fn().mockRejectedValueOnce('Evil');
+
+      // Execute
+      const resultPromise = chatroomService.emitChatroomMessage(
+        chatroomUUID,
+        userUUID,
+        message
+      );
+
+      // Validate
+      await expect(resultPromise).rejects.toStrictEqual(Error('Evil'));
+      expect(eventLedger.submitEvent).toHaveBeenCalledTimes(1);
+      expect(eventLedger.submitEvent).toHaveBeenCalledWith(chatroomUUID, {
+        key: expect.any(String),
+        value: {
+          message: processedMessage,
+          chatroomUUID,
+          userUUID,
+          timestamp: expect.any(String),
+        },
+      });
+    });
   });
 
   describe('Get Chatroom Users', () => {

--- a/src/events/kafka/errors/producer-not-found.error.ts
+++ b/src/events/kafka/errors/producer-not-found.error.ts
@@ -1,0 +1,7 @@
+class ProducerNotFoundError extends Error {
+  constructor(topic: string) {
+    super(`Producer for topic ${topic} not found`);
+  }
+}
+
+export default ProducerNotFoundError;

--- a/src/events/kafka/kafka.ledger.ts
+++ b/src/events/kafka/kafka.ledger.ts
@@ -6,6 +6,7 @@ import {
   EventLedger,
   EventProducer,
 } from '../events.types';
+import ProducerNotFoundError from './errors/producer-not-found.error';
 import createKafkaConsumer from './kafka.consumer';
 import createKafkaProducer from './kakfa.producer';
 
@@ -43,7 +44,7 @@ function createKafkaLedger(kafkaInstance: Kafka): EventLedger {
 
   async function submitEvent(topic: string, message: EventBusEvent) {
     if (!producers.has(topic)) {
-      throw new Error(`Producer for topic ${topic} not found`);
+      throw new ProducerNotFoundError(topic);
     }
     const producer = producers.get(topic);
     if (producer) {


### PR DESCRIPTION
error was being thrown because it tries to emit a user left message to the chatroom when the producer sending the message was already destroyed