### PR TITLE
Adding leave chatroom api, seperating from websocket

### DIFF
--- a/src/chatrooms/chatrooms.router.ts
+++ b/src/chatrooms/chatrooms.router.ts
@@ -36,6 +36,13 @@ chatroomRouter.get(
   chatroomController.listChatrooms
 );
 
+chatroomRouter.delete(
+  '/leave',
+  leaveChatroomValidator,
+  chatroomController.leaveChatroom,
+  chatroomController.emitUserLeftChatroomMessage
+);
+
 chatroomWebSocketRouter.onWebSocketConnection(
   '/',
   chatroomWebsocketValidator,
@@ -49,22 +56,6 @@ chatroomWebSocketRouter.onWebSocketMessage(
   receiveChatroomMessageValidator,
   chatroomController.addUserChatroomsToContext,
   chatroomController.receiveChatroomMessage
-);
-
-chatroomWebSocketRouter.onWebSocketClose(
-  '/',
-  leaveChatroomValidator,
-  chatroomController.addUserChatroomsToContext,
-  chatroomController.leaveChatroom,
-  chatroomController.emitUserLeftChatroomMessage
-);
-
-chatroomWebSocketRouter.onWebSocketError(
-  '/',
-  leaveChatroomValidator,
-  chatroomController.addUserChatroomsToContext,
-  chatroomController.leaveChatroom,
-  chatroomController.emitUserLeftChatroomMessage
 );
 
 export { chatroomRouter, chatroomWebSocketRouter };

--- a/src/chatrooms/validation/leave-chatroom.schema.ts
+++ b/src/chatrooms/validation/leave-chatroom.schema.ts
@@ -1,18 +1,16 @@
 import { JSONSchemaType } from 'ajv';
 import ajv from '../../middleware/validation/ajv';
 import { VALIDATION_ERRORS } from '../../middleware/validation/error-messages';
-import createWebSocketValidator, {
-  getConnectionUserUUIDContextData,
-} from '../../websocket/websocket.validator';
+import createExpressValidator from '../../middleware/validation/express.validator';
 
 type LeaveChatroomSchema = {
-  userUUID: string;
+  chatroomUUID: string;
 };
 
 const leaveChatroomSchema: JSONSchemaType<LeaveChatroomSchema> = {
   type: 'object',
   properties: {
-    userUUID: {
+    chatroomUUID: {
       type: 'string',
       format: 'uuid',
       nullable: false,
@@ -22,17 +20,13 @@ const leaveChatroomSchema: JSONSchemaType<LeaveChatroomSchema> = {
       },
     },
   },
-
-  required: ['userUUID'],
-  additionalProperties: true,
+  required: ['chatroomUUID'],
+  additionalProperties: false,
 };
 
-const validateCreateChatroom = ajv.compile(leaveChatroomSchema);
+const validateLeaveChatroom = ajv.compile(leaveChatroomSchema);
 
-const leaveChatroomValidator = createWebSocketValidator(
-  validateCreateChatroom,
-  getConnectionUserUUIDContextData
-);
+const leaveChatroomValidator = createExpressValidator(validateLeaveChatroom);
 
 export { leaveChatroomValidator };
 export type { LeaveChatroomSchema };

--- a/src/middleware/validation/express.validator.ts
+++ b/src/middleware/validation/express.validator.ts
@@ -7,7 +7,9 @@ function createExpressValidator(
   validateFunction: ValidateFunction
 ): RequestHandler {
   return async (req: Request, res: Response, next: NextFunction) => {
-    const input = req.method === 'GET' ? req.query : req.body;
+    const methodNeedsQueryParams =
+      req.method === 'GET' || req.method === 'DELETE';
+    const input = methodNeedsQueryParams ? req.query : req.body;
     const isValid = validateFunction(input);
     if (!isValid && validateFunction.errors) {
       // If schema validation failed and error occurred return with formatted error message


### PR DESCRIPTION
Making the leave chatroom its own api instead of being tied to WebSocket disconnect. This way connections can be lost and regained without the user leaving the chatroom